### PR TITLE
feat: expand stories API with tags and bulk operations

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { prisma } from "@/core/prisma";
 import { log } from "@/lib/logger";
 import type { JWTPayload, ApiResponse, User } from "@/types/api";
+import { getBearerToken } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const requestStartTime = Date.now();
@@ -10,16 +11,14 @@ export async function GET(request: NextRequest) {
   
   try {
     // Get token from Authorization header
-    const authHeader = request.headers.get('authorization');
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    const token = getBearerToken(request.headers.get('authorization'));
+    if (!token) {
       log.warn('Missing or invalid authorization header', { endpoint: '/api/auth/me' });
       return NextResponse.json(
         { message: 'Token không hợp lệ', success: false },
         { status: 401 }
       );
     }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
 
     // Verify token with proper typing
     let decoded: JWTPayload;

--- a/src/app/api/dashboard/stats/route.ts
+++ b/src/app/api/dashboard/stats/route.ts
@@ -1,40 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { caslGuard, RequiredRule } from "@/core/auth/casl.guard";
-import jwt from "jsonwebtoken";
-
 import { prisma } from "@/core/prisma";
-
-// Helper function to get user from request
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    // Get token from Authorization header
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return null;
-    }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-
-    // Verify token
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || "fallback-secret"
-    ) as {
-      userId: string;
-      email: string;
-      role: string;
-      tenantId?: string;
-    };
-
-    return {
-      sub: decoded.userId,
-      tenantId: decoded.tenantId,
-      roles: [decoded.role],
-    };
-  } catch (error) {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 // GET /api/dashboard/stats - Lấy thống kê tổng quan hệ thống
 export async function GET(request: NextRequest) {

--- a/src/app/api/lessons/route.ts
+++ b/src/app/api/lessons/route.ts
@@ -2,36 +2,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { Prisma, LearningLevel } from "@prisma/client";
 import { caslGuard, RequiredRule } from "@/core/auth/casl.guard";
-import jwt from "jsonwebtoken";
 import { prisma } from "@/core/prisma";
-
-type JwtPayload = {
-  userId: string;
-  email: string;
-  role: string;
-  tenantId?: string;
-};
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader?.startsWith("Bearer ")) return null;
-
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(
-        token,
-        process.env.JWT_SECRET || "fallback-secret"
-    ) as JwtPayload;
-
-    return {
-      sub: decoded.userId,
-      tenantId: decoded.tenantId,
-      roles: [decoded.role],
-    };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 // GET /api/lessons
 export async function GET(request: NextRequest) {

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -3,19 +3,18 @@ import jwt, { JwtPayload } from "jsonwebtoken";
 import type { UserRole } from "@prisma/client";
 
 import { prisma } from "@/core/prisma";
+import { getBearerToken } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   try {
     // Get token from Authorization header
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    const token = getBearerToken(request.headers.get("authorization"));
+    if (!token) {
       return NextResponse.json(
         { message: "Token không hợp lệ" },
         { status: 401 }
       );
     }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
 
     // Verify token - using Prisma generated types
     interface CustomJwtPayload extends JwtPayload {

--- a/src/app/api/permissions/[id]/route.ts
+++ b/src/app/api/permissions/[id]/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/permissions/route.ts
+++ b/src/app/api/permissions/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const user = await getUserFromRequest(request);

--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -1,23 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || "fallback-secret"
-    ) as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function PUT(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,24 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-// helper to get user context
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || "fallback-secret"
-    ) as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const user = await getUserFromRequest(request);

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -1,40 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { caslGuard, RequiredRule } from "@/core/auth/casl.guard";
-import jwt from "jsonwebtoken";
-
 import { prisma } from "@/core/prisma";
-
-// Helper function to get user from request
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    // Get token from Authorization header
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return null;
-    }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-
-    // Verify token
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || "fallback-secret"
-    ) as {
-      userId: string;
-      email: string;
-      role: string;
-      tenantId?: string;
-    };
-
-    return {
-      sub: decoded.userId,
-      tenantId: decoded.tenantId,
-      roles: [decoded.role],
-    };
-  } catch (error) {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 // GET /api/quizzes - Lấy danh sách quizzes
 export async function GET(request: NextRequest) {

--- a/src/app/api/roles/[id]/permissions/route.ts
+++ b/src/app/api/roles/[id]/permissions/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/roles/[id]/route.ts
+++ b/src/app/api/roles/[id]/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   const user = await getUserFromRequest(request);

--- a/src/app/api/stories/bulk/route.ts
+++ b/src/app/api/stories/bulk/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from "next/server";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+import { prisma } from "@/core/prisma";
+import { StoryType, DifficultyLevel, ContentStatus } from "@prisma/client";
+import { getUserFromRequest } from "@/lib/auth";
+
+// PUT /api/stories/bulk - bulk update stories
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rules = [{ action: "update", subject: "Story" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) {
+      return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const ids: string[] = body?.ids ?? [];
+    const data = body?.data ?? {};
+
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return NextResponse.json({ error: "ids is required" }, { status: 400 });
+    }
+
+    // Validate enums
+    if (data.storyType && !Object.values(StoryType).includes(data.storyType)) {
+      return NextResponse.json(
+        { error: `Invalid storyType: ${data.storyType}` },
+        { status: 400 }
+      );
+    }
+    if (data.difficulty && !Object.values(DifficultyLevel).includes(data.difficulty)) {
+      return NextResponse.json(
+        { error: `Invalid difficulty: ${data.difficulty}` },
+        { status: 400 }
+      );
+    }
+    if (data.status && !Object.values(ContentStatus).includes(data.status)) {
+      return NextResponse.json(
+        { error: `Invalid status: ${data.status}` },
+        { status: 400 }
+      );
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (data.title !== undefined) updateData.title = data.title;
+    if (data.content !== undefined) updateData.content = data.content;
+    if (data.storyType !== undefined) updateData.storyType = data.storyType;
+    if (data.difficulty !== undefined) updateData.difficulty = data.difficulty;
+    if (data.estimatedMinutes !== undefined) updateData.estimatedMinutes = data.estimatedMinutes;
+    if (data.chemRatio !== undefined) updateData.chemRatio = data.chemRatio;
+    if (data.lessonId !== undefined) updateData.lessonId = data.lessonId;
+    if (data.status !== undefined) updateData.status = data.status;
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+    }
+
+    const result = await prisma.story.updateMany({
+      where: { id: { in: ids }, tenantId: user.tenantId ?? undefined },
+      data: updateData,
+    });
+
+    return NextResponse.json({ count: result.count });
+  } catch (err) {
+    console.error("Error bulk updating stories:", err);
+    return NextResponse.json(
+      { error: "Failed to bulk update stories" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE /api/stories/bulk - bulk delete stories
+export async function DELETE(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rules = [{ action: "delete", subject: "Story" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) {
+      return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+    }
+
+    const body = await request.json();
+    const ids: string[] = body?.ids ?? [];
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return NextResponse.json({ error: "ids is required" }, { status: 400 });
+    }
+
+    const result = await prisma.story.deleteMany({
+      where: { id: { in: ids }, tenantId: user.tenantId ?? undefined },
+    });
+
+    return NextResponse.json({ count: result.count });
+  } catch (err) {
+    console.error("Error bulk deleting stories:", err);
+    return NextResponse.json(
+      { error: "Failed to bulk delete stories" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+import { prisma } from "@/core/prisma";
+import { getUserFromRequest } from "@/lib/auth";
+
+// GET /api/tags - List tags for current tenant
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rules = [{ action: "read", subject: "Tag" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) {
+      return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+    }
+
+    const tags = await prisma.tag.findMany({
+      where: user.tenantId ? { tenantId: user.tenantId } : undefined,
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+      take: 200,
+    });
+
+    return NextResponse.json(tags);
+  } catch (err) {
+    console.error("Error fetching tags:", err);
+    return NextResponse.json(
+      { error: "Failed to fetch tags" },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/api/users/[id]/permissions/route.ts
+++ b/src/app/api/users/[id]/permissions/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/users/[id]/roles/route.ts
+++ b/src/app/api/users/[id]/roles/route.ts
@@ -1,20 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
-import type { JWTPayload } from "@/types/api";
-
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
-    const token = authHeader.substring(7);
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
-    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 export async function GET(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,39 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
-import jwt from "jsonwebtoken";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { buildAbility } from "@/core/auth/ability";
 import { accessibleBy } from "@casl/prisma";
 import { log } from "@/lib/logger";
-import type { JWTPayload, ApiResponse, User, DatabaseWhereClause, RequiredRule } from "@/types/api";
+import type { ApiResponse, User, DatabaseWhereClause, RequiredRule } from "@/types/api";
 import bcrypt from "bcryptjs";
-
-// Helper function to get user from request
-async function getUserFromRequest(request: NextRequest) {
-  try {
-    // Get token from Authorization header
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader || !authHeader.startsWith("Bearer ")) {
-      return null;
-    }
-
-    const token = authHeader.substring(7); // Remove 'Bearer ' prefix
-
-    // Verify token
-    const decoded = jwt.verify(
-      token,
-      process.env.JWT_SECRET || "fallback-secret"
-    ) as JWTPayload;
-
-    return {
-      sub: decoded.userId,
-      tenantId: decoded.tenantId,
-      roles: [decoded.role],
-    };
-  } catch {
-    return null;
-  }
-}
+import { getUserFromRequest } from "@/lib/auth";
 
 // GET /api/users - Lấy danh sách users với search
 export async function GET(request: NextRequest) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,25 @@
+import jwt from "jsonwebtoken";
+import type { JWTPayload } from "@/types/api";
+
+export interface UserContext {
+  sub: string;
+  tenantId?: string;
+  roles: string[];
+}
+
+export function getBearerToken(authHeader: string | null): string | null {
+  if (!authHeader) return null;
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export async function getUserFromRequest(request: Request): Promise<UserContext | null> {
+  try {
+    const token = getBearerToken(request.headers.get("authorization"));
+    if (!token) return null;
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || "fallback-secret") as JWTPayload;
+    return { sub: decoded.userId, tenantId: decoded.tenantId, roles: [decoded.role] };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add tag API endpoint for tenant-scoped tag listing
- expand stories endpoints to handle filters, tags, and full metadata
- support bulk update and delete for stories
- centralize bearer token parsing into shared auth util

## Testing
- `npm test`
- `npm run lint` *(fails: React Hook "useEffect" is called conditionally and display name warning)*

------
https://chatgpt.com/codex/tasks/task_e_689daede2fac8329b5f0981402cbd67b