### PR TITLE
feat: add storybook docs for ui components

### DIFF
--- a/src/components/admin/admin-nav.stories.mdx
+++ b/src/components/admin/admin-nav.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { AdminNav } from './admin-nav';
+
+<Meta title="Admin/AdminNav" component={AdminNav}/>
+
+# AdminNav
+
+Navigation menu for the admin dashboard.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Next.js routing context.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AdminNav} />

--- a/src/components/admin/user-profile-menu.stories.mdx
+++ b/src/components/admin/user-profile-menu.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { UserProfileMenu } from './user-profile-menu';
+
+<Meta title="Admin/UserProfileMenu" component={UserProfileMenu}/>
+
+# UserProfileMenu
+
+Dropdown menu showing the current user's profile and actions.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth context to display user info.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={UserProfileMenu} />

--- a/src/components/auth/FieldBasedInput.stories.mdx
+++ b/src/components/auth/FieldBasedInput.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { FieldBasedInput } from './FieldBasedInput';
+
+<Meta title="Auth/FieldBasedInput" component={FieldBasedInput} argTypes={{
+  action:{ control:{ type:'text' }, description:'Ability action to check' },
+  subject:{ control:{ type:'text' }, description:'Ability subject for the model' },
+  field:{ control:{ type:'text' }, description:'Name of the protected field' },
+  type:{ control:{ type:'text' }, description:'Input type', table:{ defaultValue:{ summary:'text' } } },
+  placeholder:{ control:{ type:'text' }, description:'Placeholder text' }
+}}/>
+
+# FieldBasedInput
+
+Input that only renders when the user has permission for a specific field.
+
+<Canvas>
+  <Story name="Example">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth and Ability providers to render.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={FieldBasedInput} />

--- a/src/components/auth/LoginForm.stories.mdx
+++ b/src/components/auth/LoginForm.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { LoginForm } from './LoginForm';
+
+<Meta title="Auth/LoginForm" component={LoginForm}/>
+
+# LoginForm
+
+Authentication form for users to sign in.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth context to function.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={LoginForm} />

--- a/src/components/auth/RegisterForm.stories.mdx
+++ b/src/components/auth/RegisterForm.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { RegisterForm } from './RegisterForm';
+
+<Meta title="Auth/RegisterForm" component={RegisterForm}/>
+
+# RegisterForm
+
+User registration form supporting student and coach roles.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth context to function.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={RegisterForm} />

--- a/src/components/auth/RoleBasedButton.stories.mdx
+++ b/src/components/auth/RoleBasedButton.stories.mdx
@@ -1,0 +1,20 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { RoleBasedButton } from './RoleBasedButton';
+
+<Meta title="Auth/RoleBasedButton" component={RoleBasedButton} argTypes={{
+  action:{ control:{ type:'text' }, description:'Ability action to check' },
+  subject:{ control:{ type:'text' }, description:'Ability subject' },
+  children:{ control:{ type:'text' }, description:'Button label' }
+}}/>
+
+# RoleBasedButton
+
+Button that renders only when the current user is authorized.
+
+<Canvas>
+  <Story name="Example">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth and Ability providers to render.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={RoleBasedButton} />

--- a/src/components/auth/RoleBasedLink.stories.mdx
+++ b/src/components/auth/RoleBasedLink.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { RoleBasedLink } from './RoleBasedLink';
+
+<Meta title="Auth/RoleBasedLink" component={RoleBasedLink} argTypes={{
+  href:{ control:{ type:'text' }, description:'Destination URL' },
+  action:{ control:{ type:'text' }, description:'Ability action to check' },
+  subject:{ control:{ type:'text' }, description:'Ability subject' },
+  children:{ control:{ type:'text' }, description:'Link label' },
+  className:{ control:{ type:'text' }, description:'Additional CSS classes' }
+}}/>
+
+# RoleBasedLink
+
+Link that only renders when the user has permission.
+
+<Canvas>
+  <Story name="Example">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth and Ability providers to render.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={RoleBasedLink} />

--- a/src/components/auth/TokenRefreshProvider.stories.mdx
+++ b/src/components/auth/TokenRefreshProvider.stories.mdx
@@ -1,0 +1,18 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { TokenRefreshProvider } from './TokenRefreshProvider';
+
+<Meta title="Auth/TokenRefreshProvider" component={TokenRefreshProvider} argTypes={{
+  children:{ control:false, description:'Content rendered within the provider' }
+}}/>
+
+# TokenRefreshProvider
+
+Provider that handles automatic token refreshing for authenticated sessions.
+
+<Canvas>
+  <Story name="Usage">
+    {() => <div className="text-sm text-muted-foreground">Wrap your app with TokenRefreshProvider inside Auth context.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={TokenRefreshProvider} />

--- a/src/components/debug/TokenDebugPanel.stories.mdx
+++ b/src/components/debug/TokenDebugPanel.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { TokenDebugPanel } from './TokenDebugPanel';
+
+<Meta title="Debug/TokenDebugPanel" component={TokenDebugPanel}/>
+
+# TokenDebugPanel
+
+Development utility panel for inspecting auth tokens.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Only visible in development and requires Auth context.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={TokenDebugPanel} />

--- a/src/components/layout/AppHeader.stories.mdx
+++ b/src/components/layout/AppHeader.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { AppHeader } from './AppHeader';
+
+<Meta title="Layout/AppHeader" component={AppHeader}/>
+
+# AppHeader
+
+Top application header that adapts navigation based on user role.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Auth context and Next.js routing.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AppHeader} />

--- a/src/components/layout/ConditionalHeader.stories.mdx
+++ b/src/components/layout/ConditionalHeader.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { ConditionalHeader } from './ConditionalHeader';
+
+<Meta title="Layout/ConditionalHeader" component={ConditionalHeader}/>
+
+# ConditionalHeader
+
+Wrapper that hides the AppHeader on admin pages.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires Next.js routing.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={ConditionalHeader} />

--- a/src/components/ui/alert.stories.mdx
+++ b/src/components/ui/alert.stories.mdx
@@ -1,0 +1,38 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Alert, AlertTitle, AlertDescription } from './alert';
+import { Info } from 'lucide-react';
+
+<Meta title="UI/Alert" component={Alert} argTypes={{
+  variant: {
+    control: { type: 'select' },
+    options: ['default','destructive'],
+    description: 'Visual style of the alert',
+    table: { defaultValue: { summary: 'default' } }
+  },
+  children: { control: false }
+}}/>
+
+# Alert
+
+Displays important information to the user.
+
+<Canvas>
+  <Story name="Default" args={{ variant: 'default' }}>{(args) => (
+    <Alert {...args}>
+      <Info className="h-4 w-4" />
+      <AlertTitle>Heads up!</AlertTitle>
+      <AlertDescription>
+        You can add components to your app using the CLI.
+      </AlertDescription>
+    </Alert>
+  )}</Story>
+  <Story name="Destructive" args={{ variant: 'destructive' }}>{(args) => (
+    <Alert {...args}>
+      <Info className="h-4 w-4" />
+      <AlertTitle>Error</AlertTitle>
+      <AlertDescription>Something went wrong.</AlertDescription>
+    </Alert>
+  )}</Story>
+</Canvas>
+
+<ArgsTable of={Alert} />

--- a/src/components/ui/avatar.stories.mdx
+++ b/src/components/ui/avatar.stories.mdx
@@ -1,0 +1,30 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Avatar, AvatarImage, AvatarFallback } from './avatar';
+
+<Meta title="UI/Avatar" component={Avatar} argTypes={{
+  children: { control: false }
+}}/>
+
+# Avatar
+
+Displays a user profile image or fallback initials.
+
+<Canvas>
+  <Story name="Image">{{
+    render: () => (
+      <Avatar>
+        <AvatarImage src="https://github.com/shadcn.png" alt="User" />
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>
+    ),
+  }}</Story>
+  <Story name="Fallback">{{
+    render: () => (
+      <Avatar>
+        <AvatarFallback>JD</AvatarFallback>
+      </Avatar>
+    ),
+  }}</Story>
+</Canvas>
+
+<ArgsTable of={Avatar} />

--- a/src/components/ui/avatar.stories.mdx
+++ b/src/components/ui/avatar.stories.mdx
@@ -10,21 +10,21 @@ import { Avatar, AvatarImage, AvatarFallback } from './avatar';
 Displays a user profile image or fallback initials.
 
 <Canvas>
-  <Story name="Image">{{
-    render: () => (
+  <Story name="Image">
+    {() => (
       <Avatar>
         <AvatarImage src="https://github.com/shadcn.png" alt="User" />
         <AvatarFallback>JD</AvatarFallback>
       </Avatar>
-    ),
-  }}</Story>
-  <Story name="Fallback">{{
-    render: () => (
+    )}
+  </Story>
+  <Story name="Fallback">
+    {() => (
       <Avatar>
         <AvatarFallback>JD</AvatarFallback>
       </Avatar>
-    ),
-  }}</Story>
+    )}
+  </Story>
 </Canvas>
 
 <ArgsTable of={Avatar} />

--- a/src/components/ui/button.stories.mdx
+++ b/src/components/ui/button.stories.mdx
@@ -1,0 +1,36 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Button } from './button';
+
+<Meta title="UI/Button" component={Button} argTypes={{
+  variant: {
+    control: { type: 'select' },
+    options: ['default','destructive','outline','secondary','ghost','link'],
+    description: 'Visual style of the button',
+    table: { defaultValue: { summary: 'default' } }
+  },
+  size: {
+    control: { type: 'select' },
+    options: ['default','sm','lg','icon'],
+    description: 'Button size',
+    table: { defaultValue: { summary: 'default' } }
+  },
+  asChild: {
+    control: { type: 'boolean' },
+    description: 'Render the button as a child component'
+  },
+  children: {
+    control: { type: 'text' },
+    description: 'Button label'
+  }
+}}/>
+
+# Button
+
+The primary button component used throughout the application.
+
+<Canvas>
+  <Story name="Default" args={{ children: 'Button' }} />
+  <Story name="Destructive" args={{ variant: 'destructive', children: 'Delete' }} />
+</Canvas>
+
+<ArgsTable of={Button} />

--- a/src/components/ui/button.stories.mdx
+++ b/src/components/ui/button.stories.mdx
@@ -15,8 +15,9 @@ import { Button } from './button';
     table: { defaultValue: { summary: 'default' } }
   },
   asChild: {
-    control: { type: 'boolean' },
-    description: 'Render the button as a child component'
+    control: false,
+    table: { disable: true },
+    description: 'Render the button as a child component. Disabled in docs to avoid Slot-only usage requiring element children.'
   },
   children: {
     control: { type: 'text' },

--- a/src/components/ui/card.stories.mdx
+++ b/src/components/ui/card.stories.mdx
@@ -1,0 +1,25 @@
+import { Meta, Story, Canvas } from '@storybook/blocks';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from './card';
+
+<Meta title="UI/Card" component={Card} />
+
+# Card
+
+A container for grouping related content.
+
+<Canvas>
+  <Story name="Default">{{
+    render: () => (
+      <Card className="w-[350px]">
+        <CardHeader>
+          <CardTitle>Card Title</CardTitle>
+          <CardDescription>Card description goes here.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p>Card content</p>
+        </CardContent>
+        <CardFooter>Card footer</CardFooter>
+      </Card>
+    ),
+  }}</Story>
+</Canvas>

--- a/src/components/ui/dropdown-menu.stories.mdx
+++ b/src/components/ui/dropdown-menu.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta, Story, Canvas } from '@storybook/blocks';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator
+} from './dropdown-menu';
+import { Button } from './button';
+
+<Meta title="UI/DropdownMenu" />
+
+# DropdownMenu
+
+Displays a menu triggered by a button.
+
+<Canvas>
+  <Story name="Default">{{
+    render: () => (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button>Open</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>My Account</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem>Profile</DropdownMenuItem>
+          <DropdownMenuItem>Settings</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    ),
+  }}</Story>
+</Canvas>

--- a/src/components/ui/input.stories.mdx
+++ b/src/components/ui/input.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Input } from './input';
+
+<Meta title="UI/Input" component={Input} argTypes={{
+  type: {
+    control: { type: 'text' },
+    description: 'HTML input type',
+    table: { defaultValue: { summary: 'text' } }
+  },
+  placeholder: {
+    control: { type: 'text' },
+    description: 'Placeholder text'
+  },
+  disabled: {
+    control: { type: 'boolean' },
+    description: 'Disable the input'
+  }
+}}/>
+
+# Input
+
+Standard text input element.
+
+<Canvas>
+  <Story name="Default" args={{ placeholder: 'Enter text...' }} />
+  <Story name="Password" args={{ type: 'password', placeholder: 'Password' }} />
+</Canvas>
+
+<ArgsTable of={Input} />

--- a/src/components/ui/label.stories.mdx
+++ b/src/components/ui/label.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Label } from './label';
+
+<Meta title="UI/Label" component={Label} argTypes={{
+  children: {
+    control: { type: 'text' },
+    description: 'Label text'
+  },
+  htmlFor: {
+    control: { type: 'text' },
+    description: 'ID of the associated input'
+  }
+}}/>
+
+# Label
+
+Associates text with a form control.
+
+<Canvas>
+  <Story name="Default" args={{ children: 'Email' }} />
+</Canvas>
+
+<ArgsTable of={Label} />

--- a/src/components/ui/navigation-menu.stories.mdx
+++ b/src/components/ui/navigation-menu.stories.mdx
@@ -1,0 +1,39 @@
+import { Meta, Story, Canvas } from '@storybook/blocks';
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink
+} from './navigation-menu';
+
+<Meta title="UI/NavigationMenu" />
+
+# NavigationMenu
+
+Responsive navigation menu with dropdown content.
+
+<Canvas>
+  <Story name="Default">{{
+    render: () => (
+      <NavigationMenu>
+        <NavigationMenuList>
+          <NavigationMenuItem>
+            <NavigationMenuTrigger>Menu</NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <ul className="grid gap-3 p-4 w-[200px]">
+                <li>
+                  <NavigationMenuLink href="#">Item 1</NavigationMenuLink>
+                </li>
+                <li>
+                  <NavigationMenuLink href="#">Item 2</NavigationMenuLink>
+                </li>
+              </ul>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
+    ),
+  }}</Story>
+</Canvas>

--- a/src/core/auth/AbilityProvider.stories.mdx
+++ b/src/core/auth/AbilityProvider.stories.mdx
@@ -1,0 +1,35 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import AbilityProvider from './AbilityProvider';
+
+<Meta title="Core/Auth/AbilityProvider" component={AbilityProvider} argTypes={{
+  rules: {
+    control: 'object',
+    description: 'CASL rules supplied from the server',
+    table: { type: { summary: 'ServerRule[] | null' } }
+  },
+  user: {
+    control: 'object',
+    description: 'Current user context used to build ability',
+    table: { type: { summary: '{ id: string; roles: string[]; tenantId?: string } | null' } }
+  },
+  children: {
+    control: 'text',
+    description: 'Elements wrapped by the provider'
+  }
+}} />
+
+# AbilityProvider
+
+Context provider that builds a CASL ability from user and rule information.
+
+<Canvas>
+  <Story name="Default" args={{ user: { id: '1', roles: ['admin'] }, rules: [] }}>
+    {(args) => (
+      <AbilityProvider {...args}>
+        <div className="text-sm">Child content rendered within AbilityProvider.</div>
+      </AbilityProvider>
+    )}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AbilityProvider} />

--- a/src/core/auth/AuthContextBridge.stories.mdx
+++ b/src/core/auth/AuthContextBridge.stories.mdx
@@ -1,0 +1,21 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import AuthContextBridge from './AuthContextBridge';
+
+<Meta title="Core/Auth/AuthContextBridge" component={AuthContextBridge} argTypes={{
+  children: {
+    control: 'text',
+    description: 'Content rendered when auth state is bridged'
+  }
+}} />
+
+# AuthContextBridge
+
+Connects AuthContext to AbilityProvider. Requires the application AuthContext; preview shows placeholder.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires AuthContext and Next.js environment.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={AuthContextBridge} />

--- a/src/core/auth/Require.stories.mdx
+++ b/src/core/auth/Require.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import { Require } from './Require';
+
+<Meta title="Core/Auth/Require" component={Require} argTypes={{
+  action: {
+    control: 'text',
+    description: 'Action to check permissions for'
+  },
+  subject: {
+    control: 'text',
+    description: 'Subject or resource being accessed'
+  },
+  children: {
+    control: 'text',
+    description: 'Content rendered when access is granted'
+  }
+}} />
+
+# Require
+
+Component that enforces authorization checks before rendering children.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires AuthContext, AbilityProvider and Next.js router.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Require} />

--- a/src/shared/components/Can.stories.mdx
+++ b/src/shared/components/Can.stories.mdx
@@ -1,0 +1,33 @@
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/blocks';
+import Can from './Can';
+
+<Meta title="Shared/Can" component={Can} argTypes={{
+  I: {
+    control: 'text',
+    description: 'Action to verify'
+  },
+  a: {
+    control: 'text',
+    description: 'Subject or resource to check'
+  },
+  passThrough: {
+    control: 'boolean',
+    description: 'Render children regardless of permission'
+  },
+  children: {
+    control: 'text',
+    description: 'Content or render function'
+  }
+}} />
+
+# Can
+
+Utility component for conditional rendering based on authorization rules.
+
+<Canvas>
+  <Story name="Preview">
+    {() => <div className="text-sm text-muted-foreground">Requires AuthContext and AbilityProvider.</div>}
+  </Story>
+</Canvas>
+
+<ArgsTable of={Can} />


### PR DESCRIPTION
## Summary
- document Button, Input, Card, Alert, Avatar, Label, DropdownMenu and NavigationMenu components with MDX stories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ded31b2f4832996bc8f7e509c0555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Storybook pages with interactive examples and prop tables for many components: Alert, Avatar, Button, Card, Dropdown Menu, Input, Label, Navigation Menu, AdminNav, UserProfileMenu, TokenDebugPanel, and more.
  * Added auth-related docs and previews (LoginForm, RegisterForm, RoleBasedButton/Link, FieldBasedInput, TokenRefreshProvider) and layout docs (AppHeader, ConditionalHeader) with usage notes and variant demos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->