### PR TITLE
feat: generate story chunks and stats

### DIFF
--- a/src/app/stories/StoryList.tsx
+++ b/src/app/stories/StoryList.tsx
@@ -1,0 +1,81 @@
+"use client";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import {
+  buildPublicStoriesListQuery,
+  useCreatePublicStory,
+} from "@/features/stories/hooks";
+
+export default function StoryList() {
+  const { data, isPending, isError, error } = useQuery(
+    buildPublicStoriesListQuery()
+  );
+  const createStory = useCreatePublicStory();
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+
+  if (isPending) return <p>Loading stories...</p>;
+  if (isError)
+    return (
+      <p style={{ color: "red" }}>Error: {(error as Error).message}</p>
+    );
+
+  return (
+    <section style={{ display: "grid", gap: 16 }}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          createStory.mutate(
+            {
+              title,
+              content,
+              storyType: "custom",
+              difficulty: "beginner",
+            },
+            {
+              onSuccess: () => {
+                setTitle("");
+                setContent("");
+              },
+            }
+          );
+        }}
+        style={{ display: "grid", gap: 8, maxWidth: 400 }}
+      >
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Title"
+          required
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Content"
+          required
+          rows={4}
+        />
+        <button type="submit" disabled={createStory.isPending}>
+          {createStory.isPending ? "Creating..." : "Add Story"}
+        </button>
+      </form>
+
+      <ul style={{ display: "grid", gap: 8 }}>
+        {data?.map((s) => (
+          <li
+            key={s.id}
+            style={{
+              padding: 8,
+              border: "1px solid #ddd",
+              borderRadius: 4,
+            }}
+          >
+            <h4 style={{ margin: "0 0 4px" }}>{s.title}</h4>
+            <p style={{ margin: 0, fontSize: 14 }}>{s.content}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/src/app/stories/page.tsx
+++ b/src/app/stories/page.tsx
@@ -1,0 +1,19 @@
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { getQueryClient } from "../get-query-client";
+import StoryList from "./StoryList";
+import { buildPublicStoriesListQuery } from "@/features/stories/hooks";
+
+export default async function StoriesPage() {
+  const qc = getQueryClient();
+  await qc.prefetchQuery(buildPublicStoriesListQuery());
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h2>Stories</h2>
+      <HydrationBoundary state={dehydrate(qc)}>
+        <StoryList />
+      </HydrationBoundary>
+    </main>
+  );
+}
+

--- a/src/lib/story-chunker.ts
+++ b/src/lib/story-chunker.ts
@@ -33,10 +33,6 @@ export function generateStoryChunks(content: string): GeneratedChunk[] {
   return chunks;
 }
 
-/**
- * Calculate statistics for a story based on its chunks.
- * Returns total word count and chemRatio (percentage of English words).
- */
 export function calculateStoryStats(chunks: GeneratedChunk[]): {
   wordCount: number;
   chemRatio: number;
@@ -45,7 +41,11 @@ export function calculateStoryStats(chunks: GeneratedChunk[]): {
     (sum, chunk) => sum + chunk.chunkText.split(/\s+/).filter(Boolean).length,
     0
   );
-  const chemWords = chunks.filter((c) => c.type === "chem").length;
+  const chemWords = chunks.reduce(
+    (sum, c) =>
+      sum + (c.type === "chem" ? c.chunkText.split(/\s+/).filter(Boolean).length : 0),
+    0
+  );
   const chemRatio = totalWords > 0 ? chemWords / totalWords : 0;
 
   return { wordCount: totalWords, chemRatio };

--- a/src/lib/story-chunker.ts
+++ b/src/lib/story-chunker.ts
@@ -1,0 +1,53 @@
+import { ChunkType } from "@/features/stories/hooks";
+
+export interface GeneratedChunk {
+  chunkText: string;
+  type: ChunkType;
+}
+
+/**
+ * Generate story chunks from a block of content.
+ * English words (ASCII letters) are marked as `chem` chunks,
+ * while surrounding Vietnamese text becomes `normal` chunks.
+ *
+ * Example:
+ *   "Hôm nay tôi có một interview quan trọng" =>
+ *   [
+ *     { chunkText: "Hôm nay tôi có một", type: "normal" },
+ *     { chunkText: "interview", type: "chem" },
+ *     { chunkText: "quan trọng", type: "normal" }
+ *   ]
+ */
+export function generateStoryChunks(content: string): GeneratedChunk[] {
+  const parts = content.split(/([A-Za-z]+)/);
+  const chunks: GeneratedChunk[] = [];
+
+  for (const part of parts) {
+    const text = part.trim();
+    if (!text) continue;
+
+    const type: ChunkType = /^[A-Za-z]+$/.test(text) ? "chem" : "normal";
+    chunks.push({ chunkText: text, type });
+  }
+
+  return chunks;
+}
+
+/**
+ * Calculate statistics for a story based on its chunks.
+ * Returns total word count and chemRatio (percentage of English words).
+ */
+export function calculateStoryStats(chunks: GeneratedChunk[]): {
+  wordCount: number;
+  chemRatio: number;
+} {
+  const totalWords = chunks.reduce(
+    (sum, chunk) => sum + chunk.chunkText.split(/\s+/).filter(Boolean).length,
+    0
+  );
+  const chemWords = chunks.filter((c) => c.type === "chem").length;
+  const chemRatio = totalWords > 0 ? chemWords / totalWords : 0;
+
+  return { wordCount: totalWords, chemRatio };
+}
+


### PR DESCRIPTION
## Summary
- generate story chunks from content and compute stats for word count and chem ratio
- create stories with default settings and automatically generated chunks
- add basic UI to list and create stories using the public stories API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e025a3fdc8329aa56a0ecf11e3288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added Stories page that lists public stories with faster initial load.
  * Introduced a form to create new public stories with inline validation and loading states.

* Refactor
  * Story submissions are now automatically analyzed and chunked on the server, with word count and ratios saved.
  * Default story settings (type, difficulty, duration, status) now use consistent app-wide defaults.
  * Improved reliability of story creation and list refresh with smarter caching and hydration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->