### PR TITLE
feat: add user progress tracking

### DIFF
--- a/src/__tests__/api/progress.test.ts
+++ b/src/__tests__/api/progress.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+import { DELETE } from "@/app/api/progress/[id]/route";
+import { prisma } from "@/core/prisma";
+import { getUserFromRequest } from "@/core/auth/getUser";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+
+jest.mock("@/core/prisma", () => ({
+  prisma: {
+    userProgress: {
+      findFirst: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("@/core/auth/getUser", () => ({
+  getUserFromRequest: jest.fn(),
+}));
+
+jest.mock("@/core/auth/casl.guard", () => ({
+  caslGuardWithPolicies: jest.fn(),
+}));
+
+const mockPrisma = prisma as any;
+const mockGetUser = getUserFromRequest as jest.MockedFunction<
+  typeof getUserFromRequest
+>;
+const mockCasl = caslGuardWithPolicies as jest.MockedFunction<
+  typeof caslGuardWithPolicies
+>;
+
+describe("/api/progress/[id] DELETE", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("deletes progress record", async () => {
+    mockGetUser.mockResolvedValue({ sub: "u1", tenantId: "t1" });
+    mockCasl.mockResolvedValue({ allowed: true, error: null });
+    mockPrisma.userProgress.findFirst.mockResolvedValue({ id: "p1" });
+    mockPrisma.userProgress.delete.mockResolvedValue({});
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/progress/p1",
+      { method: "DELETE" }
+    );
+
+    const res = await DELETE(request, { params: { id: "p1" } });
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.userProgress.delete).toHaveBeenCalledWith({
+      where: { id: "p1" },
+    });
+  });
+
+  it("returns 404 if record not found", async () => {
+    mockGetUser.mockResolvedValue({ sub: "u1", tenantId: "t1" });
+    mockCasl.mockResolvedValue({ allowed: true, error: null });
+    mockPrisma.userProgress.findFirst.mockResolvedValue(null);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/progress/p1",
+      { method: "DELETE" }
+    );
+
+    const res = await DELETE(request, { params: { id: "p1" } });
+
+    expect(res.status).toBe(404);
+  });
+});
+

--- a/src/__tests__/features/progress/hooks.test.tsx
+++ b/src/__tests__/features/progress/hooks.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  useLessonProgress,
+  useProgressList,
+  useUpsertProgress,
+  useUpdateProgress,
+  useDeleteProgress,
+} from "@/features/progress/hooks";
+import { api } from "@/core/api/api";
+
+// Mock API
+jest.mock("@/core/api/api");
+const mockApi = api as jest.MockedFunction<typeof api>;
+
+// Test wrapper
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  Wrapper.displayName = "QueryClientWrapper";
+  return Wrapper;
+};
+
+describe("Progress Hooks", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches lesson progress", async () => {
+    const mockProgress = {
+      id: "p1",
+      lessonId: "l1",
+      userId: "u1",
+      status: "in_progress" as const,
+      lastViewedAt: new Date().toISOString(),
+      tenantId: "t1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    mockApi.mockResolvedValueOnce(mockProgress);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useLessonProgress("l1"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "/api/progress?lessonId=l1",
+      expect.any(Object)
+    );
+    expect(result.current.data).toEqual(mockProgress);
+  });
+
+  it("lists progress records", async () => {
+    const mockList = [] as any[];
+    mockApi.mockResolvedValueOnce(mockList);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => useProgressList({ status: "completed" }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockApi).toHaveBeenCalledWith(
+      "/api/progress?status=completed",
+      expect.any(Object)
+    );
+    expect(result.current.data).toEqual(mockList);
+  });
+
+  it("upserts progress", async () => {
+    const mockProgress = {
+      id: "p1",
+      lessonId: "l1",
+      userId: "u1",
+      status: "completed" as const,
+      lastViewedAt: new Date().toISOString(),
+      tenantId: "t1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    mockApi.mockResolvedValueOnce(mockProgress);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useUpsertProgress(), { wrapper });
+
+    result.current.mutate({ lessonId: "l1", status: "completed" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockApi).toHaveBeenCalledWith("/api/progress", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ lessonId: "l1", status: "completed" }),
+    });
+  });
+
+  it("updates progress", async () => {
+    const mockProgress = {
+      id: "p1",
+      lessonId: "l1",
+      userId: "u1",
+      status: "completed" as const,
+      lastViewedAt: new Date().toISOString(),
+      tenantId: "t1",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    mockApi.mockResolvedValueOnce(mockProgress);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useUpdateProgress(), { wrapper });
+
+    result.current.mutate({ id: "p1", data: { status: "completed" } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockApi).toHaveBeenCalledWith("/api/progress/p1", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "completed" }),
+    });
+  });
+
+  it("deletes progress", async () => {
+    mockApi.mockResolvedValueOnce({ success: true });
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useDeleteProgress(), { wrapper });
+
+    result.current.mutate({ id: "p1" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockApi).toHaveBeenCalledWith("/api/progress/p1", { method: "DELETE" });
+  });
+});
+

--- a/src/app/api/progress/[id]/route.ts
+++ b/src/app/api/progress/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/core/prisma";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+import { getUserFromRequest } from "@/core/auth/getUser";
+import type { RequiredRule } from "@/types/api";
+import { ProgressStatus } from "@prisma/client";
+
+// GET /api/progress/[id] - fetch specific progress record
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const rules: RequiredRule[] = [{ action: "read", subject: "UserProgress" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+
+    const progress = await prisma.userProgress.findFirst({
+      where: {
+        id: params.id,
+        userId: user.sub,
+        ...(user.tenantId ? { tenantId: user.tenantId } : {}),
+      },
+    });
+
+    if (!progress) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(progress);
+  } catch (err) {
+    console.error("Error fetching progress:", err);
+    return NextResponse.json({ error: "Failed to fetch progress" }, { status: 500 });
+  }
+}
+
+// PUT /api/progress/[id] - update progress status or lastViewedAt
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const rules: RequiredRule[] = [{ action: "update", subject: "UserProgress" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+
+    const body = await request.json();
+    const { status, lastViewedAt } = body ?? {};
+
+    const allowedStatuses = Object.values(ProgressStatus) as string[];
+    if (status && !allowedStatuses.includes(status)) {
+      return NextResponse.json({ error: `Invalid status: ${status}` }, { status: 400 });
+    }
+
+    const existing = await prisma.userProgress.findFirst({
+      where: {
+        id: params.id,
+        userId: user.sub,
+        ...(user.tenantId ? { tenantId: user.tenantId } : {}),
+      },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const progress = await prisma.userProgress.update({
+      where: { id: params.id },
+      data: {
+        ...(status ? { status: status as ProgressStatus } : {}),
+        ...(lastViewedAt ? { lastViewedAt: new Date(lastViewedAt) } : {}),
+      },
+    });
+
+    return NextResponse.json(progress);
+  } catch (err) {
+    console.error("Error updating progress:", err);
+    return NextResponse.json({ error: "Failed to update progress" }, { status: 500 });
+  }
+}
+
+// DELETE /api/progress/[id] - remove a progress record
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const rules: RequiredRule[] = [{ action: "delete", subject: "UserProgress" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+
+    const existing = await prisma.userProgress.findFirst({
+      where: {
+        id: params.id,
+        userId: user.sub,
+        ...(user.tenantId ? { tenantId: user.tenantId } : {}),
+      },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await prisma.userProgress.delete({ where: { id: params.id } });
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error("Error deleting progress:", err);
+    return NextResponse.json({ error: "Failed to delete progress" }, { status: 500 });
+  }
+}

--- a/src/app/api/progress/route.ts
+++ b/src/app/api/progress/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/core/prisma";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+import { getUserFromRequest } from "@/core/auth/getUser";
+import type { RequiredRule } from "@/types/api";
+import { Prisma, ProgressStatus } from "@prisma/client";
+
+// GET /api/progress - list or fetch progress for current user
+export async function GET(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const rules: RequiredRule[] = [{ action: "read", subject: "UserProgress" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+
+    const { searchParams } = new URL(request.url);
+    const lessonId = searchParams.get("lessonId");
+    const statusParam = searchParams.get("status");
+
+    const where: Prisma.UserProgressWhereInput = {
+      userId: user.sub,
+      ...(user.tenantId ? { tenantId: user.tenantId } : {}),
+    };
+
+    if (lessonId) where.lessonId = lessonId;
+    if (statusParam) where.status = statusParam as ProgressStatus;
+
+    const progressRecords = await prisma.userProgress.findMany({
+      where,
+      orderBy: { updatedAt: "desc" },
+    });
+
+    if (lessonId) {
+      return NextResponse.json(progressRecords[0] || null);
+    }
+
+    return NextResponse.json(progressRecords);
+  } catch (err) {
+    console.error("Error fetching user progress:", err);
+    return NextResponse.json({ error: "Failed to fetch progress" }, { status: 500 });
+  }
+}
+
+// POST /api/progress - create or update progress (upsert)
+export async function POST(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+    const rules: RequiredRule[] = [{ action: "create", subject: "UserProgress" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) return NextResponse.json({ error: error || "Forbidden" }, { status: 403 });
+
+    const body = await request.json();
+    const { lessonId, status = ProgressStatus.IN_PROGRESS } = body ?? {};
+
+    if (!lessonId) {
+      return NextResponse.json({ error: "lessonId is required" }, { status: 400 });
+    }
+
+    if (!user.tenantId) {
+      return NextResponse.json({ error: "tenantId is required" }, { status: 400 });
+    }
+
+    const allowedStatuses = Object.values(ProgressStatus) as string[];
+    if (status && !allowedStatuses.includes(status)) {
+      return NextResponse.json({ error: `Invalid status: ${status}` }, { status: 400 });
+    }
+
+    const progress = await prisma.userProgress.upsert({
+      where: {
+        userId_lessonId: {
+          userId: user.sub,
+          lessonId,
+        },
+      },
+      update: {
+        status: status as ProgressStatus,
+        lastViewedAt: new Date(),
+      },
+      create: {
+        userId: user.sub,
+        lessonId,
+        tenantId: user.tenantId,
+        status: status as ProgressStatus,
+        lastViewedAt: new Date(),
+      },
+    });
+
+    return NextResponse.json(progress, { status: 201 });
+  } catch (err) {
+    console.error("Error updating user progress:", err);
+    return NextResponse.json({ error: "Failed to update progress" }, { status: 500 });
+  }
+}

--- a/src/features/progress/hooks.ts
+++ b/src/features/progress/hooks.ts
@@ -1,0 +1,129 @@
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { keyFactory } from "@/core/api/keyFactory";
+import { api } from "@/core/api/api";
+import type { ProgressStatusType } from "@/types/schema";
+
+export interface UserProgress {
+  id: string;
+  userId: string;
+  lessonId: string;
+  status: ProgressStatusType;
+  lastViewedAt: string | null;
+  tenantId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpsertProgressData {
+  lessonId: string;
+  status?: ProgressStatusType;
+}
+
+export interface UpdateProgressData {
+  status?: ProgressStatusType;
+  lastViewedAt?: string;
+}
+
+export interface ListProgressParams {
+  status?: ProgressStatusType;
+}
+
+export const buildLessonProgressQuery = (lessonId: string) =>
+  queryOptions({
+    queryKey: keyFactory.detail("user-progress", lessonId),
+    queryFn: ({ signal }) =>
+      api<UserProgress | null>(`/api/progress?lessonId=${lessonId}`, { signal }),
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+    enabled: !!lessonId,
+  });
+
+export const buildProgressListQuery = (params?: ListProgressParams) =>
+  queryOptions({
+    queryKey: keyFactory.list("user-progress", params),
+    queryFn: ({ signal }) => {
+      const searchParams = new URLSearchParams();
+      if (params?.status) searchParams.append("status", params.status);
+      const url = `/api/progress${
+        searchParams.toString() ? `?${searchParams.toString()}` : ""
+      }`;
+      return api<UserProgress[]>(url, { signal });
+    },
+    staleTime: 5 * 60_000,
+    gcTime: 10 * 60_000,
+  });
+
+export const useLessonProgress = (lessonId: string) =>
+  useQuery(buildLessonProgressQuery(lessonId));
+
+export const useProgressList = (params?: ListProgressParams) =>
+  useQuery(buildProgressListQuery(params));
+
+export function useUpsertProgress() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpsertProgressData) =>
+      api<UserProgress>("/api/progress", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.detail("user-progress", data.lessonId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.list("user-progress"),
+      });
+    },
+  });
+}
+
+export function useUpdateProgress() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateProgressData }) =>
+      api<UserProgress>(`/api/progress/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.detail("user-progress", data.lessonId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.list("user-progress"),
+      });
+    },
+  });
+}
+
+export function useDeleteProgress() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }: { id: string }) =>
+      api(`/api/progress/${id}`, { method: "DELETE" }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: keyFactory.list("user-progress"),
+      });
+      if ((variables as any).lessonId) {
+        queryClient.invalidateQueries({
+          queryKey: keyFactory.detail(
+            "user-progress",
+            (variables as any).lessonId as string
+          ),
+        });
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- allow deleting user progress via new API endpoint with tenant and user checks
- add query hooks for listing, updating, and removing progress entries with cache invalidation
- cover progress API and hooks with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e763e067c83298b6f78821a933dcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced API endpoints to retrieve, create/update, modify, and delete individual progress records, plus list and per-lesson retrieval.
  - Added client-side hooks to read and manage progress with caching and automatic refresh after mutations.
  - Improved validation and error responses for invalid requests and missing records.

- Tests
  - Added comprehensive tests for progress hooks covering read, list, create/update, and delete flows.
  - Added route tests validating DELETE behavior and not-found scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->