### PR TITLE
refactor: rely on shared Prisma client in API routes

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
-import { PrismaClient } from "@prisma/client";
 
 import { prisma } from "@/core/prisma";
 
@@ -88,7 +87,5 @@ export async function POST(request: NextRequest) {
       { message: "Lỗi server. Vui lòng thử lại sau." },
       { status: 500 }
     );
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import jwt, { JwtPayload } from 'jsonwebtoken';
-import { PrismaClient } from '@prisma/client';
 
 import { prisma } from "@/core/prisma";
 
@@ -94,7 +93,5 @@ export async function POST(request: NextRequest) {
       { message: 'Lỗi server. Vui lòng thử lại sau.' },
       { status: 500 }
     );
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
-import { PrismaClient } from "@prisma/client";
 import { z } from "zod";
 
 import { prisma } from "@/core/prisma";
@@ -108,7 +107,5 @@ export async function POST(request: NextRequest) {
       { message: "Lỗi server. Vui lòng thử lại sau." },
       { status: 500 }
     );
-  } finally {
-    await prisma.$disconnect();
   }
 }

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -60,7 +60,5 @@ export async function GET(request: NextRequest) {
       { message: "Lỗi server. Vui lòng thử lại sau." },
       { status: 500 }
     );
-  } finally {
-    await prisma.$disconnect();
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant `prisma.$disconnect()` calls in API routes
- depend on shared `src/core/prisma` instance for connection reuse

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec07153d48329b00c62744017cef2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized backend resource handling across authentication and profile endpoints to reduce overhead and improve reliability under load. No API changes or behavior adjustments.

* **Chores**
  * Standardized internal request lifecycle management for auth-related routes.
  * General cleanup to align with shared infrastructure patterns. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->