### PR TITLE
refactor: centralize token management for API client and context

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,12 +8,8 @@ import React, {
   useCallback,
 } from "react";
 import { useRouter } from "next/navigation";
-import {
-  setAuthToken,
-  getAuthToken,
-  refreshToken,
-  clearCSRFToken,
-} from "@/core/api/api";
+import { setAuthToken, getAuthToken, refreshToken } from "@/core/api/tokenManager";
+import { clearCSRFToken } from "@/core/api/api";
 
 // Types
 interface User {

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -1,4 +1,13 @@
 import { ApiError } from "./errorHandling";
+import {
+  tokenManager,
+  setAuthToken,
+  getAuthToken,
+  refreshToken,
+  getRefreshToken,
+  isTokenExpiringSoon,
+  getExpiresAt,
+} from "./tokenManager";
 
 /* ======================================
  * Types
@@ -17,172 +26,10 @@ export type RequestInterceptor = (
 export type ResponseInterceptor = (response: Response) => Response | Promise<Response>;
 export type ErrorInterceptor = (error: Error) => Error | Promise<Error>;
 
-export interface TokenData {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt: number; // epoch ms
-  tokenType: "Bearer";
-}
-
 /* ======================================
  * Utils
  * ====================================== */
 const isClient = () => typeof window !== "undefined";
-const now = () => Date.now();
-
-/* ======================================
- * TokenStorage (localStorage only, SSR-safe)
- * ====================================== */
-const TOKEN_KEY = "auth_token_data";
-
-const TokenStorage = {
-  load(): TokenData | null {
-    if (!isClient()) return null;
-    const raw = localStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    try {
-      const json = typeof atob === "function" ? atob(raw) : raw;
-      return JSON.parse(json) as TokenData;
-    } catch {
-      return null;
-    }
-  },
-  save(data: TokenData | null) {
-    if (!isClient()) return;
-    if (!data) {
-      localStorage.removeItem(TOKEN_KEY);
-      return;
-    }
-    const json = JSON.stringify(data);
-    const encoded = typeof btoa === "function" ? btoa(json) : json;
-    localStorage.setItem(TOKEN_KEY, encoded);
-  },
-  clear() {
-    if (!isClient()) return;
-    localStorage.removeItem(TOKEN_KEY);
-  },
-};
-
-/* ======================================
- * TokenManager (singleton)
- * ====================================== */
-class TokenManager {
-  private static _instance: TokenManager | null = null;
-  static getInstance(): TokenManager {
-    if (!this._instance) this._instance = new TokenManager();
-    return this._instance;
-  }
-
-  private cached: TokenData | null = null;
-  private _initialized = false;
-
-  private refreshing = false;
-  private _refreshPromise: Promise<string | null> | null = null;
-  private readonly REFRESH_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-
-  /** Expose refresh in-flight safely (read-only) */
-  getRefreshInFlight(): Promise<string | null> | null {
-    return this._refreshPromise;
-  }
-
-  /** Sync init to avoid race */
-  init(): void {
-    if (this._initialized) return;
-    if (isClient()) {
-      this.cached = TokenStorage.load();
-    }
-    this._initialized = true;
-  }
-
-  isInitialized(): boolean {
-    return this._initialized;
-  }
-
-  set(accessToken: string, expiresInSec = 3600, refreshToken?: string) {
-    this.init();
-    this.cached = {
-      accessToken,
-      refreshToken,
-      tokenType: "Bearer",
-      expiresAt: now() + expiresInSec * 1000,
-    };
-    TokenStorage.save(this.cached);
-  }
-
-  clear() {
-    this.cached = null;
-    TokenStorage.clear();
-  }
-
-  getAccessTokenSync(): string | null {
-    this.init();
-    if (!this.cached) return null;
-    if (now() >= this.cached.expiresAt) {
-      this.clear();
-      return null;
-    }
-    return this.cached.accessToken;
-  }
-
-  getRefreshTokenSync(): string | null {
-    this.init();
-    return this.cached?.refreshToken ?? null;
-  }
-
-  getExpiresAtSync(): number | null {
-    this.init();
-    return this.cached?.expiresAt ?? null;
-  }
-
-  isExpiringSoon(): boolean {
-    this.init();
-    if (!this.cached) return false;
-    return now() >= this.cached.expiresAt - this.REFRESH_THRESHOLD;
-  }
-
-  /** Single-flight refresh. Caller supplies actual refresh fetcher */
-  async refresh(
-      fetcher: (refreshToken: string) => Promise<{
-        accessToken: string;
-        expiresIn: number;
-        refreshToken?: string;
-      } | null>
-  ): Promise<string | null> {
-    if (this.refreshing && this._refreshPromise) return this._refreshPromise;
-
-    const rt = this.getRefreshTokenSync();
-    if (!rt) return null;
-
-    this.refreshing = true;
-    this._refreshPromise = (async () => {
-      try {
-        const result = await fetcher(rt);
-        if (!result) {
-          this.clear();
-          if (isClient()) {
-            window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-          }
-          return null;
-        }
-        this.set(result.accessToken, result.expiresIn, result.refreshToken);
-        return result.accessToken;
-      } catch {
-        this.clear();
-        if (isClient()) {
-          window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-        }
-        return null;
-      } finally {
-        this.refreshing = false;
-        this._refreshPromise = null;
-      }
-    })();
-
-    return this._refreshPromise;
-  }
-}
-
-export const tokenManager = TokenManager.getInstance();
 
 /* ======================================
  * CSRF (simple cache)
@@ -281,29 +128,6 @@ export const apiClient = new ApiClient({
 });
 
 /* ======================================
- * Refresh fetcher (customize theo API của bạn)
- * ====================================== */
-const performRefresh = async (refreshToken: string) => {
-  const res = await fetch("/api/auth/refresh", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "same-origin",
-    body: JSON.stringify({ refreshToken }),
-  });
-  if (!res.ok) return null;
-  const data = (await res.json()) as {
-    accessToken: string;
-    expiresIn?: number;
-    refreshToken?: string;
-  };
-  return {
-    accessToken: data.accessToken,
-    expiresIn: data.expiresIn ?? 3600,
-    refreshToken: data.refreshToken,
-  };
-};
-
-/* ======================================
  * Default interceptors
  * ====================================== */
 apiClient.addRequestInterceptor(async (config) => {
@@ -315,14 +139,14 @@ apiClient.addRequestInterceptor(async (config) => {
   if (inFlight) await inFlight;
 
   // proactive refresh if expiring soon and we have RT
-  if (tokenManager.isExpiringSoon() && tokenManager.getRefreshTokenSync()) {
-    await tokenManager.refresh(performRefresh);
+  if (isTokenExpiringSoon() && getRefreshToken()) {
+    await refreshToken();
   }
 
   const headers = new Headers(config.headers as HeadersInit);
 
   // attach access token
-  const access = tokenManager.getAccessTokenSync();
+  const access = getAuthToken();
   if (access) headers.set("Authorization", `Bearer ${access}`);
 
   // attach CSRF for non-GET
@@ -353,14 +177,14 @@ apiClient.addErrorInterceptor(async (error) => {
   if (!(error instanceof ApiError)) return error;
 
   if (error.status === 401) {
-    const hasRT = !!tokenManager.getRefreshTokenSync();
+    const hasRT = !!getRefreshToken();
     if (!hasRT) {
       tokenManager.clear();
       if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
       return error;
     }
 
-    const newToken = await tokenManager.refresh(performRefresh);
+    const newToken = await refreshToken();
     if (!newToken) {
       tokenManager.clear();
       if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
@@ -377,20 +201,7 @@ apiClient.addErrorInterceptor(async (error) => {
 export const api = <T = unknown,>(input: RequestInfo, init?: RequestInit): Promise<T> =>
     apiClient.request<T>(input, init);
 
-export const setAuthToken = (
-    token: string | null,
-    expiresIn?: number,
-    refreshToken?: string
-): void => {
-  if (token) tokenManager.set(token, expiresIn, refreshToken);
-  else tokenManager.clear();
-};
-
-export const getAuthToken = (): string | null => tokenManager.getAccessTokenSync();
-export const getRefreshToken = (): string | null => tokenManager.getRefreshTokenSync();
-export const isTokenExpiringSoon = (): boolean => tokenManager.isExpiringSoon();
-
-export const refreshToken = (): Promise<string | null> => tokenManager.refresh(performRefresh);
+export { setAuthToken, getAuthToken, getRefreshToken, isTokenExpiringSoon, refreshToken };
 
 export const getCSRFTokenForClient = (): Promise<string | null> => getCSRFToken();
 
@@ -400,13 +211,13 @@ export const getTokenStatus = (): {
   expiresAt: number | null;
   refreshInFlight: boolean;
 } => {
-  const access = tokenManager.getAccessTokenSync();
-  const refresh = tokenManager.getRefreshTokenSync();
-  const expiring = tokenManager.isExpiringSoon();
+  const access = getAuthToken();
+  const refresh = getRefreshToken();
+  const expiring = isTokenExpiringSoon();
   return {
     hasToken: !!access || !!refresh,
     isExpiringSoon: expiring,
-    expiresAt: tokenManager.getExpiresAtSync(),
+    expiresAt: getExpiresAt(),
     refreshInFlight: tokenManager.getRefreshInFlight() !== null,
   };
 };


### PR DESCRIPTION
## Summary
- move token storage/refresh logic into a dedicated `tokenManager`
- reuse `tokenManager` instance in API client
- expose set/get/refresh helpers for AuthContext and API client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec07049b48329b253822902763e17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated authentication token handling into a dedicated module for cleaner, more maintainable session management.
  * Streamlined token refresh logic for a smoother, more consistent sign-in experience across the app.

* **Bug Fixes**
  * Improved reliability of automatic token refresh to reduce unexpected sign-outs and 401 errors.
  * Ensured authorization headers are consistently applied, minimizing intermittent request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->