### PR TITLE
feat: migrate auth tokens to HttpOnly cookies

### DIFF
--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -1,188 +1,28 @@
 import { ApiError } from "./errorHandling";
+import { tokenManager } from "./tokenManager";
 
 /* ======================================
  * Types
  * ====================================== */
-// Enhanced request configuration interface
 export interface ApiRequestConfig extends RequestInit {
-    url: string;
-    timeout?: number;
-    retries?: number;
+  url: string;
+  timeout?: number;
+  retries?: number;
 }
 
 export type RequestInterceptor = (
-    config: ApiRequestConfig
+  config: ApiRequestConfig
 ) => ApiRequestConfig | Promise<ApiRequestConfig>;
 
-export type ResponseInterceptor = (response: Response) => Response | Promise<Response>;
-export type ErrorInterceptor = (error: Error) => Error | Promise<Error>;
+export type ResponseInterceptor = (
+  response: Response
+) => Response | Promise<Response>;
 
-export interface TokenData {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt: number; // epoch ms
-  tokenType: "Bearer";
-}
+export type ErrorInterceptor = (
+  error: Error
+) => Error | Promise<Error>;
 
-/* ======================================
- * Utils
- * ====================================== */
 const isClient = () => typeof window !== "undefined";
-const now = () => Date.now();
-
-/* ======================================
- * TokenStorage (localStorage only, SSR-safe)
- * ====================================== */
-const TOKEN_KEY = "auth_token_data";
-
-const TokenStorage = {
-  load(): TokenData | null {
-    if (!isClient()) return null;
-    const raw = localStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    try {
-      const json = typeof atob === "function" ? atob(raw) : raw;
-      return JSON.parse(json) as TokenData;
-    } catch {
-      return null;
-    }
-  },
-  save(data: TokenData | null) {
-    if (!isClient()) return;
-    if (!data) {
-      localStorage.removeItem(TOKEN_KEY);
-      return;
-    }
-    const json = JSON.stringify(data);
-    const encoded = typeof btoa === "function" ? btoa(json) : json;
-    localStorage.setItem(TOKEN_KEY, encoded);
-  },
-  clear() {
-    if (!isClient()) return;
-    localStorage.removeItem(TOKEN_KEY);
-  },
-};
-
-/* ======================================
- * TokenManager (singleton)
- * ====================================== */
-class TokenManager {
-  private static _instance: TokenManager | null = null;
-  static getInstance(): TokenManager {
-    if (!this._instance) this._instance = new TokenManager();
-    return this._instance;
-  }
-
-  private cached: TokenData | null = null;
-  private _initialized = false;
-
-  private refreshing = false;
-  private _refreshPromise: Promise<string | null> | null = null;
-  private readonly REFRESH_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-
-  /** Expose refresh in-flight safely (read-only) */
-  getRefreshInFlight(): Promise<string | null> | null {
-    return this._refreshPromise;
-  }
-
-  /** Sync init to avoid race */
-  init(): void {
-    if (this._initialized) return;
-    if (isClient()) {
-      this.cached = TokenStorage.load();
-    }
-    this._initialized = true;
-  }
-
-  isInitialized(): boolean {
-    return this._initialized;
-  }
-
-  set(accessToken: string, expiresInSec = 3600, refreshToken?: string) {
-    this.init();
-    this.cached = {
-      accessToken,
-      refreshToken,
-      tokenType: "Bearer",
-      expiresAt: now() + expiresInSec * 1000,
-    };
-    TokenStorage.save(this.cached);
-  }
-
-  clear() {
-    this.cached = null;
-    TokenStorage.clear();
-  }
-
-  getAccessTokenSync(): string | null {
-    this.init();
-    if (!this.cached) return null;
-    if (now() >= this.cached.expiresAt) {
-      this.clear();
-      return null;
-    }
-    return this.cached.accessToken;
-  }
-
-  getRefreshTokenSync(): string | null {
-    this.init();
-    return this.cached?.refreshToken ?? null;
-  }
-
-  getExpiresAtSync(): number | null {
-    this.init();
-    return this.cached?.expiresAt ?? null;
-  }
-
-  isExpiringSoon(): boolean {
-    this.init();
-    if (!this.cached) return false;
-    return now() >= this.cached.expiresAt - this.REFRESH_THRESHOLD;
-  }
-
-  /** Single-flight refresh. Caller supplies actual refresh fetcher */
-  async refresh(
-      fetcher: (refreshToken: string) => Promise<{
-        accessToken: string;
-        expiresIn: number;
-        refreshToken?: string;
-      } | null>
-  ): Promise<string | null> {
-    if (this.refreshing && this._refreshPromise) return this._refreshPromise;
-
-    const rt = this.getRefreshTokenSync();
-    if (!rt) return null;
-
-    this.refreshing = true;
-    this._refreshPromise = (async () => {
-      try {
-        const result = await fetcher(rt);
-        if (!result) {
-          this.clear();
-          if (isClient()) {
-            window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-          }
-          return null;
-        }
-        this.set(result.accessToken, result.expiresIn, result.refreshToken);
-        return result.accessToken;
-      } catch {
-        this.clear();
-        if (isClient()) {
-          window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-        }
-        return null;
-      } finally {
-        this.refreshing = false;
-        this._refreshPromise = null;
-      }
-    })();
-
-    return this._refreshPromise;
-  }
-}
-
-export const tokenManager = TokenManager.getInstance();
 
 /* ======================================
  * CSRF (simple cache)
@@ -230,18 +70,19 @@ class ApiClient {
     const url = typeof input === "string" ? input : input.url;
     if (/^https?:\/\//i.test(url)) return url;
     if (this.opts?.baseURL) return `${this.opts.baseURL}${url}`;
-    return url; // prefer relative path on client
+    return url;
   }
 
   async request<T = unknown>(input: RequestInfo, init?: RequestInit): Promise<T> {
     try {
-      let config: RequestInit & { url: string } = {
+      let config: ApiRequestConfig = {
         ...init,
         url: this.resolveURL(input),
         headers: {
           "Content-Type": "application/json",
           ...(init?.headers || {}),
         },
+        credentials: "include",
         signal: init?.signal,
       };
 
@@ -255,17 +96,28 @@ class ApiClient {
         response = await i(response);
       }
 
-      const isJson = response.headers.get("content-type")?.includes("application/json");
-      const body: unknown = isJson ? await response.json().catch(() => undefined) : undefined;
+      const isJson = response.headers
+        .get("content-type")
+        ?.includes("application/json");
+      const body: unknown = isJson
+        ? await response.json().catch(() => undefined)
+        : undefined;
 
       if (!response.ok) {
-        type ErrorBody = { message?: string; error?: string; [k: string]: unknown };
-        const obj = (typeof body === "object" && body !== null) ? (body as ErrorBody) : undefined;
+        type ErrorBody = {
+          message?: string;
+          error?: string;
+          [k: string]: unknown;
+        };
+        const obj =
+          typeof body === "object" && body !== null
+            ? (body as ErrorBody)
+            : undefined;
         const message = obj?.message || obj?.error || `HTTP ${response.status}`;
         throw new ApiError(message, response.status, body, `HTTP_${response.status}`);
       }
 
-      return (body as T) ?? (await response.text() as unknown as T);
+      return (body as T) ?? ((await response.text()) as unknown as T);
     } catch (err) {
       let e = err as Error;
       for (const i of this.errorInterceptors) {
@@ -276,54 +128,13 @@ class ApiClient {
   }
 }
 
-export const apiClient = new ApiClient({
-  // Optional: baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
-});
-
-/* ======================================
- * Refresh fetcher (customize theo API của bạn)
- * ====================================== */
-const performRefresh = async (refreshToken: string) => {
-  const res = await fetch("/api/auth/refresh", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "same-origin",
-    body: JSON.stringify({ refreshToken }),
-  });
-  if (!res.ok) return null;
-  const data = (await res.json()) as {
-    accessToken: string;
-    expiresIn?: number;
-    refreshToken?: string;
-  };
-  return {
-    accessToken: data.accessToken,
-    expiresIn: data.expiresIn ?? 3600,
-    refreshToken: data.refreshToken,
-  };
-};
+export const apiClient = new ApiClient();
 
 /* ======================================
  * Default interceptors
  * ====================================== */
 apiClient.addRequestInterceptor(async (config) => {
-  // ensure token loaded (sync)
-  tokenManager.init();
-
-  // wait in-flight refresh if any
-  const inFlight = tokenManager.getRefreshInFlight();
-  if (inFlight) await inFlight;
-
-  // proactive refresh if expiring soon and we have RT
-  if (tokenManager.isExpiringSoon() && tokenManager.getRefreshTokenSync()) {
-    await tokenManager.refresh(performRefresh);
-  }
-
   const headers = new Headers(config.headers as HeadersInit);
-
-  // attach access token
-  const access = tokenManager.getAccessTokenSync();
-  if (access) headers.set("Authorization", `Bearer ${access}`);
 
   // attach CSRF for non-GET
   const method = (config.method || "GET").toUpperCase();
@@ -332,10 +143,8 @@ apiClient.addRequestInterceptor(async (config) => {
     if (csrf) headers.set("X-CSRF-Token", csrf);
   }
 
-  // tracing & security
   headers.set("X-Requested-With", "XMLHttpRequest");
   if (isClient() && "randomUUID" in crypto) {
-    // TS types available if lib "DOM" is enabled
     headers.set("X-Request-ID", (crypto as Crypto).randomUUID());
   }
 
@@ -350,47 +159,26 @@ apiClient.addResponseInterceptor(async (res) => {
 });
 
 apiClient.addErrorInterceptor(async (error) => {
-  if (!(error instanceof ApiError)) return error;
-
-  if (error.status === 401) {
-    const hasRT = !!tokenManager.getRefreshTokenSync();
-    if (!hasRT) {
-      tokenManager.clear();
-      if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
-      return error;
-    }
-
-    const newToken = await tokenManager.refresh(performRefresh);
-    if (!newToken) {
-      tokenManager.clear();
-      if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
-    }
+  if (error instanceof ApiError && error.status === 401 && isClient()) {
+    window.dispatchEvent(new CustomEvent("auth:unauthorized"));
   }
-
   return error;
 });
 
 /* ======================================
- * Public API (giữ tên export để không vỡ import cũ)
+ * Public API
  * ====================================== */
-// Note: Use <T,> to avoid JSX parsing issues in environments that parse TS as TSX
 export const api = <T = unknown,>(input: RequestInfo, init?: RequestInit): Promise<T> =>
-    apiClient.request<T>(input, init);
+  apiClient.request<T>(input, init);
 
-export const setAuthToken = (
-    token: string | null,
-    expiresIn?: number,
-    refreshToken?: string
-): void => {
-  if (token) tokenManager.set(token, expiresIn, refreshToken);
-  else tokenManager.clear();
+export const setAuthToken = (): void => {
+  // Tokens are handled via HttpOnly cookies on the server
 };
 
 export const getAuthToken = (): string | null => tokenManager.getAccessTokenSync();
 export const getRefreshToken = (): string | null => tokenManager.getRefreshTokenSync();
 export const isTokenExpiringSoon = (): boolean => tokenManager.isExpiringSoon();
-
-export const refreshToken = (): Promise<string | null> => tokenManager.refresh(performRefresh);
+export const refreshToken = (): Promise<string | null> => tokenManager.refresh();
 
 export const getCSRFTokenForClient = (): Promise<string | null> => getCSRFToken();
 
@@ -406,10 +194,10 @@ export const getTokenStatus = (): {
   return {
     hasToken: !!access || !!refresh,
     isExpiringSoon: expiring,
-    expiresAt: tokenManager.getExpiresAtSync(),
+    expiresAt: null,
     refreshInFlight: tokenManager.getRefreshInFlight() !== null,
   };
 };
 
-// Named exports for advanced usage
 export { ApiError } from "./errorHandling";
+

--- a/src/core/api/tokenManager.ts
+++ b/src/core/api/tokenManager.ts
@@ -1,156 +1,58 @@
-import type { TokenData, RefreshTokenResponse } from "./types";
+import { cookies } from "next/headers";
+import type { RefreshTokenResponse } from "./types";
 
 /* ======================================
- * Utils
+ * Cookie-based TokenManager
  * ====================================== */
-const isClient = () => typeof window !== "undefined";
-const now = () => Date.now();
+const ACCESS_COOKIE = "auth_token";
+const REFRESH_COOKIE = "refresh_token";
 
-/* ======================================
- * TokenStorage (localStorage only, SSR-safe)
- * ====================================== */
-const TOKEN_KEY = "auth_token_data";
+const isServer = () => typeof window === "undefined";
 
-const TokenStorage = {
-  load(): TokenData | null {
-    if (!isClient()) return null;
-    const raw = localStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    try {
-      const json = typeof atob === "function" ? atob(raw) : raw;
-      return JSON.parse(json) as TokenData;
-    } catch {
-      return null;
-    }
-  },
-  save(data: TokenData | null) {
-    if (!isClient()) return;
-    if (!data) {
-      localStorage.removeItem(TOKEN_KEY);
-      return;
-    }
-    const json = JSON.stringify(data);
-    const encoded = typeof btoa === "function" ? btoa(json) : json;
-    localStorage.setItem(TOKEN_KEY, encoded);
-  },
-  clear() {
-    if (!isClient()) return;
-    localStorage.removeItem(TOKEN_KEY);
-  },
+const readCookie = (name: string): string | null => {
+  if (!isServer()) return null;
+  try {
+    return cookies().get(name)?.value ?? null;
+  } catch {
+    return null;
+  }
 };
 
-/* ======================================
- * TokenManager (singleton)
- * ====================================== */
 class TokenManager {
-  private static _instance: TokenManager | null = null;
-  static getInstance(): TokenManager {
-    if (!this._instance) this._instance = new TokenManager();
-    return this._instance;
-  }
-
-  private cached: TokenData | null = null;
-  private _initialized = false;
-
-  private refreshing = false;
-  private _refreshPromise: Promise<string | null> | null = null;
-  private readonly REFRESH_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-
-  /** Expose refresh in-flight safely (read-only) */
-  getRefreshInFlight(): Promise<string | null> | null {
-    return this._refreshPromise;
-  }
-
-  /** Sync init to avoid race */
-  init(): void {
-    if (this._initialized) return;
-    if (isClient()) {
-      this.cached = TokenStorage.load();
-    }
-    this._initialized = true;
-  }
+  /** Initialization is unnecessary for cookie-based storage */
+  init(): void {}
 
   isInitialized(): boolean {
-    return this._initialized;
+    return true;
   }
 
-  set(accessToken: string, expiresInSec = 3600, refreshToken?: string) {
-    this.init();
-    this.cached = {
-      accessToken,
-      refreshToken,
-      tokenType: "Bearer",
-      expiresAt: now() + expiresInSec * 1000,
-    };
-    TokenStorage.save(this.cached);
-  }
+  /** Tokens are managed via HttpOnly cookies on the server */
+  set(): void {}
 
-  clear() {
-    this.cached = null;
-    TokenStorage.clear();
-  }
+  clear(): void {}
 
   getAccessTokenSync(): string | null {
-    this.init();
-    if (!this.cached) return null;
-    if (now() >= this.cached.expiresAt) {
-      this.clear();
-      return null;
-    }
-    return this.cached.accessToken;
+    return readCookie(ACCESS_COOKIE);
   }
 
   getRefreshTokenSync(): string | null {
-    this.init();
-    return this.cached?.refreshToken ?? null;
+    return readCookie(REFRESH_COOKIE);
   }
 
   isExpiringSoon(): boolean {
-    this.init();
-    if (!this.cached) return false;
-    return now() >= this.cached.expiresAt - this.REFRESH_THRESHOLD;
+    return false;
   }
 
-  /** Single-flight refresh. Caller supplies actual refresh fetcher */
+  getRefreshInFlight(): Promise<string | null> | null {
+    return null;
+  }
+
   async refresh(
-    fetcher: (refreshToken: string) => Promise<RefreshTokenResponse | null>
+    _fetcher?: (refreshToken: string) => Promise<RefreshTokenResponse | null>
   ): Promise<string | null> {
-    if (this.refreshing && this._refreshPromise) return this._refreshPromise;
-
-    const rt = this.getRefreshTokenSync();
-    if (!rt) return null;
-
-    this.refreshing = true;
-    this._refreshPromise = (async () => {
-      try {
-        const result = await fetcher(rt);
-        if (!result) {
-          this.clear();
-          if (isClient()) {
-            window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-          }
-          return null;
-        }
-        this.set(
-          result.accessToken,
-          result.expiresIn ?? 3600,
-          result.refreshToken
-        );
-        return result.accessToken;
-      } catch {
-        this.clear();
-        if (isClient()) {
-          window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-        }
-        return null;
-      } finally {
-        this.refreshing = false;
-        this._refreshPromise = null;
-      }
-    })();
-
-    return this._refreshPromise;
+    return null;
   }
 }
 
-export const tokenManager = TokenManager.getInstance();
+export const tokenManager = new TokenManager();
+


### PR DESCRIPTION
## Summary
- replace localStorage token handling with HttpOnly cookie-based token manager
- send requests with cookies and update AuthContext to avoid direct token access
- add middleware to refresh access tokens using refresh cookies

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ec06bad348329a73b1670c4e0494d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic session refresh on missing or expired tokens, preserving login state.
  - Role-based route protection with redirects to login or unauthorized pages as needed.
  - User context injected into requests (ID, role, email, tenant) for consistent personalization.

- Improvements
  - Moved to secure, cookie-based authentication for all requests; no client-side token storage.
  - More reliable login, logout, and session checks using server-managed cookies.
  - Consistent security headers applied across responses.
  - Clearer handling of unauthorized errors, reducing unexpected sign-outs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->