### PR TITLE
require JWT_SECRET configuration for auth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Required: secret key for JWT signing
+JWT_SECRET=your-super-secret-jwt-key

--- a/middleware.ts
+++ b/middleware.ts
@@ -84,11 +84,13 @@ export function middleware(request: NextRequest) {
     }
 
     try {
+      const secret = process.env.JWT_SECRET;
+      if (!secret) {
+        throw new Error("JWT_SECRET is not configured");
+      }
+
       // Verify token
-      const decoded = jwt.verify(
-        token,
-        process.env.JWT_SECRET || "fallback-secret"
-      ) as any;
+      const decoded = jwt.verify(token, secret) as any;
       const userRole = decoded.role;
       const tenantId = decoded.tenantId;
 

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -41,6 +41,11 @@ export async function POST(request: NextRequest) {
     // Use the user's tenantId from the database
     const tenantId = user.tenantId;
 
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error("JWT_SECRET is not configured");
+    }
+
     // Generate access token (shorter expiry)
     const accessToken = jwt.sign(
       {
@@ -49,7 +54,7 @@ export async function POST(request: NextRequest) {
         role: user.role,
         tenantId: tenantId,
       },
-      process.env.JWT_SECRET || "fallback-secret",
+      secret,
       { expiresIn: "15m" } // 15 minutes for access token
     );
 
@@ -59,7 +64,7 @@ export async function POST(request: NextRequest) {
         userId: user.id,
         type: "refresh",
       },
-      process.env.JWT_SECRET || "fallback-secret",
+      secret,
       { expiresIn: "7d" } // 7 days for refresh token
     );
 

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -24,14 +24,19 @@ export async function GET(request: NextRequest) {
     let decoded: JWTPayload;
     const authStartTime = Date.now();
     
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET is not configured');
+    }
+
     try {
-      decoded = jwt.verify(token, process.env.JWT_SECRET || 'fallback-secret') as JWTPayload;
+      decoded = jwt.verify(token, secret) as JWTPayload;
       log.performance('JWT verification completed', Date.now() - authStartTime, {
         endpoint: '/api/auth/me',
         userId: decoded.userId
       });
     } catch (error) {
-      log.warn('Invalid or expired JWT token', { 
+      log.warn('Invalid or expired JWT token', {
         endpoint: '/api/auth/me',
         error: error instanceof Error ? error.message : 'Unknown error'
       });

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -22,9 +22,14 @@ export async function POST(request: NextRequest) {
       roles?: string[];
     }
     
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error('JWT_SECRET is not configured');
+    }
+
     let decoded: CustomJwtPayload;
     try {
-      decoded = jwt.verify(refreshToken, process.env.JWT_SECRET || 'fallback-secret') as CustomJwtPayload;
+      decoded = jwt.verify(refreshToken, secret) as CustomJwtPayload;
     } catch (error) {
       return NextResponse.json(
         { message: 'Refresh token không hợp lệ hoặc đã hết hạn' },
@@ -60,7 +65,7 @@ export async function POST(request: NextRequest) {
         role: user.role,
         tenantId: user.tenantId,
       },
-      process.env.JWT_SECRET || 'fallback-secret',
+      secret,
       { expiresIn: '15m' } // Shorter expiry for access token
     );
 
@@ -70,7 +75,7 @@ export async function POST(request: NextRequest) {
         userId: user.id,
         type: 'refresh',
       },
-      process.env.JWT_SECRET || 'fallback-secret',
+      secret,
       { expiresIn: '7d' }
     );
 

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -58,6 +58,11 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    const secret = process.env.JWT_SECRET;
+    if (!secret) {
+      throw new Error("JWT_SECRET is not configured");
+    }
+
     // Generate access token (shorter expiry)
     const accessToken = jwt.sign(
       {
@@ -66,7 +71,7 @@ export async function POST(request: NextRequest) {
         role: user.role,
         tenantId: user.tenantId,
       },
-      process.env.JWT_SECRET || "fallback-secret",
+      secret,
       { expiresIn: "15m" }
     );
 
@@ -76,7 +81,7 @@ export async function POST(request: NextRequest) {
         userId: user.id,
         type: "refresh",
       },
-      process.env.JWT_SECRET || "fallback-secret",
+      secret,
       { expiresIn: "7d" }
     );
 


### PR DESCRIPTION
## Summary
- enforce presence of `JWT_SECRET` in auth login, registration, refresh and me endpoints, as well as middleware
- add `.env.example` documenting required `JWT_SECRET`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ec2b395b48329ba755f4ace33f3bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Strengthened authentication by requiring a configured JWT secret for token creation and verification across login, registration, refresh, and protected routes. Removes fallback secret usage, improving security and ensuring consistent error responses when misconfigured.
- Documentation
  - Updated the environment example to include a JWT secret entry with guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->