### PR TITLE
refactor: reuse shared prisma client

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,4 +1,3 @@
-import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
 
 import { prisma } from "@/core/prisma";
@@ -599,7 +598,4 @@ main()
   .catch((e) => {
     console.error("❌ Seed failed:", e);
     process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
   });

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -5,9 +5,8 @@
  * Tracks user actions, data changes, and system events for compliance and debugging.
  */
 
-import { PrismaClient, Prisma } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { Prisma } from '@prisma/client';
+import { prisma } from "@/core/prisma";
 
 export type AuditAction = 'CREATE' | 'UPDATE' | 'DELETE' | 'LOGIN' | 'LOGOUT' | 'ACCESS';
 

--- a/src/lib/learning-analytics.ts
+++ b/src/lib/learning-analytics.ts
@@ -5,9 +5,7 @@
  * Supports comprehensive analytics for the EdTech platform.
  */
 
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { prisma } from "@/core/prisma";
 
 export interface StartLearningSessionData {
   userId: string;

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -5,9 +5,8 @@
  * Supports different notification types and delivery methods.
  */
 
-import { PrismaClient, NotificationType } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import { NotificationType } from '@prisma/client';
+import { prisma } from "@/core/prisma";
 
 export interface CreateNotificationData {
   type: NotificationType;


### PR DESCRIPTION
## Summary
- use shared prisma client in audit, learning analytics, notifications, and seed script
- drop redundant prisma.$disconnect in seed script

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ecf4dfe50832986f229e18c7e406a