### PR TITLE
refactor: improve CSRF verification

### DIFF
--- a/src/app/api/csrf/route.ts
+++ b/src/app/api/csrf/route.ts
@@ -3,15 +3,15 @@ import { getCSRFTokenForClient } from '@/lib/csrf';
 
 export async function GET() {
   try {
-    const { token } = getCSRFTokenForClient();
+    const { token, hash } = getCSRFTokenForClient();
     
     const response = NextResponse.json({ 
       csrfToken: token,
       message: 'CSRF token generated successfully' 
     });
 
-    // Set CSRF token in httpOnly cookie for additional security
-    response.cookies.set('csrf-token', token, {
+    // Store CSRF token hash in httpOnly cookie for verification
+    response.cookies.set('csrf-token', hash, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'strict',


### PR DESCRIPTION
## Summary
- require CSRF_SECRET configuration and drop fallback
- store CSRF token hash in cookie and compare via verifyCSRFToken
- update middleware to validate CSRF tokens using HMAC cookie

## Testing
- `CSRF_SECRET=test npm test`
- `CSRF_SECRET=test npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ecf54c9788329839a74f1f59b9300