### PR TITLE
Fix VocabularyPopup arrow style

### DIFF
--- a/src/app/learning/components/VocabularyPopup.tsx
+++ b/src/app/learning/components/VocabularyPopup.tsx
@@ -237,11 +237,7 @@ export function VocabularyPopup({
         {/* Arrow pointing to the word */}
         <div
           className="absolute w-0 h-0 border-l-8 border-r-8 border-t-8 border-l-transparent border-r-transparent border-t-blue-200"
-          style={{
-            left: "50%",
-            top: "-8px",
-            transform: "translateX(-50%)",
-          }}
+          style={{ left: "50%", top: "-8px", transform: "translateX(-50%)" }}
         />
       </div>
     </>


### PR DESCRIPTION
## Summary
- ensure border-t-blue-200 class stays on the same line for the arrow indicator

## Testing
- `npm test` *(fails: Unable to find element with the text; mockReturnValue is not a function; window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fd338854883299a910d4b5fc39d14