### PR TITLE
refactor: centralize CSRF helpers

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,12 +8,8 @@ import React, {
   useCallback,
 } from "react";
 import { useRouter } from "next/navigation";
-import {
-  setAuthToken,
-  getAuthToken,
-  refreshToken,
-  clearCSRFToken,
-} from "@/core/api/api";
+import { setAuthToken, getAuthToken, refreshToken } from "@/core/api/api";
+import { clearCSRFToken } from "@/core/api/csrf";
 import logger from "@/lib/logger";
 
 // Types

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -1,5 +1,6 @@
 import { ApiError } from "./errorHandling";
 import logger from "@/lib/logger";
+import { getCSRFToken } from "./csrf";
 
 /* ======================================
  * Types
@@ -186,28 +187,6 @@ class TokenManager {
 export const tokenManager = TokenManager.getInstance();
 
 /* ======================================
- * CSRF (simple cache)
- * ====================================== */
-let csrfToken: string | null = null;
-
-export const getCSRFToken = async (): Promise<string | null> => {
-  if (csrfToken) return csrfToken;
-  try {
-    const res = await fetch("/api/csrf", { credentials: "same-origin" });
-    if (!res.ok) return null;
-    const data = (await res.json()) as { csrfToken?: string };
-    csrfToken = data?.csrfToken ?? null;
-    return csrfToken;
-  } catch {
-    return null;
-  }
-};
-
-export const clearCSRFToken = () => {
-  csrfToken = null;
-};
-
-/* ======================================
  * ApiClient (fetch wrapper + interceptors)
  * ====================================== */
 class ApiClient {
@@ -391,8 +370,6 @@ export const getRefreshToken = (): string | null => tokenManager.getRefreshToken
 export const isTokenExpiringSoon = (): boolean => tokenManager.isExpiringSoon();
 
 export const refreshToken = (): Promise<string | null> => tokenManager.refresh(performRefresh);
-
-export const getCSRFTokenForClient = (): Promise<string | null> => getCSRFToken();
 
 export const getTokenStatus = (): {
   hasToken: boolean;


### PR DESCRIPTION
## Summary
- centralize CSRF token logic in src/core/api/csrf.ts
- remove duplicated CSRF helpers from api client
- update AuthContext to import clearCSRFToken from CSRF module

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, etc.)*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689fd33bccfc832999a4371f93cf9a12