### PR TITLE
feat(api): add typed global config accessor

### DIFF
--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -171,13 +171,19 @@ export const dev = process.env.NODE_ENV === 'development' ? {
  * Global configuration function
  * Call this once in your app initialization
  */
-export function configureApi(config: {
+export interface ApiConfig {
   baseUrl?: string;
   defaultHeaders?: Record<string, string>;
   timeout?: number;
   enableMonitoring?: boolean;
   enableAnalytics?: boolean;
-}) {
+}
+
+declare global {
+  var __API_CONFIG__: ApiConfig | undefined;
+}
+
+export function configureApi(config: ApiConfig) {
   // Apply global configuration
   if (config.enableMonitoring && process.env.NODE_ENV === 'development') {
     console.log('🔍 API monitoring enabled');
@@ -186,9 +192,20 @@ export function configureApi(config: {
   if (config.enableAnalytics && process.env.NODE_ENV === 'production') {
     console.log('📊 API analytics enabled');
   }
-  
+
   // Store config for use by other modules
-  (globalThis as any).__API_CONFIG__ = config;
+  globalThis.__API_CONFIG__ = config;
+}
+
+/**
+ * Get global API configuration
+ */
+export function getApiConfig(): ApiConfig {
+  const config = globalThis.__API_CONFIG__;
+  if (!config) {
+    throw new Error('API not configured');
+  }
+  return config;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add `ApiConfig` interface and global declaration
- expose `getApiConfig` helper for safe access
- remove `any` cast from `configureApi`

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fd68184e8832992a36d385eda2b39