### PR TITLE
feat: add JWT helper and unify token verification

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import jwt from "jsonwebtoken";
+import { verifyJwt } from "@/core/auth/jwt";
+import type { JWTPayload } from "@/types/api";
 
 // Security headers
 const securityHeaders = {
@@ -84,13 +85,8 @@ export function middleware(request: NextRequest) {
     }
 
     try {
-      const secret = process.env.JWT_SECRET;
-      if (!secret) {
-        throw new Error("JWT_SECRET is not configured");
-      }
-
       // Verify token
-      const decoded = jwt.verify(token, secret) as any;
+      const decoded = verifyJwt<JWTPayload>(token);
       const userRole = decoded.role;
       const tenantId = decoded.tenantId;
 

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
-import jwt from 'jsonwebtoken';
 import { prisma } from "@/core/prisma";
 import { log } from "@/lib/logger";
 import type { JWTPayload, ApiResponse, User } from "@/types/api";
 import { getBearerToken } from "@/core/auth/getUser";
+import { verifyJwt } from "@/core/auth/jwt";
 
 export async function GET(request: NextRequest) {
   const requestStartTime = Date.now();
@@ -23,14 +23,9 @@ export async function GET(request: NextRequest) {
     // Verify token with proper typing
     let decoded: JWTPayload;
     const authStartTime = Date.now();
-    
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      throw new Error('JWT_SECRET is not configured');
-    }
 
     try {
-      decoded = jwt.verify(token, secret) as JWTPayload;
+      decoded = verifyJwt<JWTPayload>(token);
       log.performance('JWT verification completed', Date.now() - authStartTime, {
         endpoint: '/api/auth/me',
         userId: decoded.userId

--- a/src/core/auth/getUser.ts
+++ b/src/core/auth/getUser.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
-import jwt from "jsonwebtoken";
 import type { JWTPayload } from "@/types/api";
+import { verifyJwt } from "@/core/auth/jwt";
 
 export interface UserContext {
   sub: string;
@@ -36,18 +36,7 @@ export async function getUserFromRequest(
     }
     if (!token) return null;
 
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      if (process.env.NODE_ENV !== "production") {
-        console.warn("getUserFromRequest: JWT_SECRET is not set; failing closed.");
-      }
-      return null;
-    }
-
-    const decoded = jwt.verify(token, secret, {
-      algorithms: ["HS256"],
-      ignoreExpiration: false,
-    }) as JWTPayload;
+    const decoded = verifyJwt<JWTPayload>(token);
     return {
       sub: decoded.userId,
       tenantId: decoded.tenantId,

--- a/src/core/auth/jwt.ts
+++ b/src/core/auth/jwt.ts
@@ -1,0 +1,19 @@
+import jwt, { JwtPayload } from 'jsonwebtoken';
+
+/**
+ * Verify a JWT token using the application's secret.
+ * Ensures consistent error handling across the codebase.
+ */
+export function verifyJwt<T extends JwtPayload>(token: string): T {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT secret is not configured');
+  }
+
+  try {
+    return jwt.verify(token, secret, { algorithms: ['HS256'] }) as T;
+  } catch {
+    throw new Error('Invalid or expired token');
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `verifyJwt` helper for consistent JWT verification
- replace direct `jwt.verify` calls with `verifyJwt`
- centralize handling of missing secrets or invalid tokens

## Testing
- `npm test` *(fails: window.matchMedia is not a function, etc.)*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fd684e96883298fcba8abe3294266