### PR TITLE
fix: preserve user in exercise submission route

### DIFF
--- a/src/app/api/learning/exercises/submit/route.ts
+++ b/src/app/api/learning/exercises/submit/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
 import { z } from "zod";
+import type { User } from "@/types/api";
 
 // Validation schema for exercise submission
 const exerciseSubmissionSchema = z.object({
@@ -20,8 +21,9 @@ const batchSubmissionSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  let user: User | null = null;
   try {
-    const user = await getUserFromRequest(request);
+    user = await getUserFromRequest(request);
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }


### PR DESCRIPTION
## Summary
- Hoist `user` variable and import type to ensure availability in catch block
- Log exercise submission errors with `user?.id`

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*

------
https://chatgpt.com/codex/tasks/task_e_689fd737f000832982a85abaf1d1ade9