### PR TITLE
refactor: add StoryChunk typing

### DIFF
--- a/src/app/learning/components/StoryReader.tsx
+++ b/src/app/learning/components/StoryReader.tsx
@@ -11,6 +11,7 @@ import { useSkipLinkTarget } from "./SkipLinks";
 import type {
   StoryReaderProps,
   UserLearningPreferences,
+  StoryChunk,
 } from "../types/learning";
 
 // Lazy load image component for better performance
@@ -201,7 +202,7 @@ export const StoryReader = React.memo(function StoryReader({
   );
 
   // Memoize processed chunks for performance
-  const processedChunks = useMemo(() => {
+  const processedChunks: StoryChunk[] = useMemo(() => {
     return story.chunks.map((chunk) => ({
       ...chunk,
       processedText: processChunkText(chunk.chunkText, chunk.type === "chem"),
@@ -286,7 +287,7 @@ const LazyChunk = React.memo(function LazyChunk({
   index,
   isHighlighted,
 }: {
-  chunk: any;
+  chunk: StoryChunk;
   index: number;
   isHighlighted: boolean;
 }) {

--- a/src/app/learning/types/learning.ts
+++ b/src/app/learning/types/learning.ts
@@ -1,4 +1,5 @@
 import type { ChunkType, DifficultyLevel, StoryType } from "@prisma/client";
+import type { ReactNode } from "react";
 
 // Story-related types
 export interface LearningStory {
@@ -22,6 +23,7 @@ export interface StoryChunk {
   chunkOrder: number;
   chunkText: string;
   type: ChunkType;
+  processedText?: ReactNode;
 }
 
 // Vocabulary-related types


### PR DESCRIPTION
## Summary
- type StoryReader chunks with StoryChunk
- allow StoryChunk to hold processed text

## Testing
- `npm test` *(fails: useAccessibility must be used within an AccessibilityProvider; window.matchMedia is not a function; etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fd7392b508329b47df2173b73b9d4