### PR TITLE
refactor: use ExerciseSubmission interface for validations

### DIFF
--- a/src/app/api/learning/exercises/submit/route.ts
+++ b/src/app/api/learning/exercises/submit/route.ts
@@ -19,6 +19,15 @@ const batchSubmissionSchema = z.object({
   submissions: z.array(exerciseSubmissionSchema),
 });
 
+interface ExerciseSubmission {
+  storyId: string;
+  exerciseId: string;
+  questionId: string;
+  userAnswer: string | string[];
+  timeSpent?: number;
+  attempts?: number;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const user = await getUserFromRequest(request);
@@ -42,14 +51,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
 
     // Check if this is a batch submission or single submission
-    let submissions: Array<{
-      storyId: string;
-      exerciseId: string;
-      questionId: string;
-      userAnswer: string | string[];
-      timeSpent?: number;
-      attempts?: number;
-    }>;
+    let submissions: ExerciseSubmission[];
 
     if (body.submissions && Array.isArray(body.submissions)) {
       // Batch submission
@@ -145,14 +147,7 @@ export async function POST(request: NextRequest) {
 }
 
 // Validate exercise answer and calculate score
-async function validateExerciseAnswer(submission: {
-  storyId: string;
-  exerciseId: string;
-  questionId: string;
-  userAnswer: string | string[];
-  timeSpent?: number;
-  attempts?: number;
-}) {
+async function validateExerciseAnswer(submission: ExerciseSubmission) {
   // Check if this is a dynamic exercise or database exercise
   if (submission.exerciseId.startsWith("dynamic-")) {
     return validateDynamicExercise(submission);
@@ -162,7 +157,7 @@ async function validateExerciseAnswer(submission: {
 }
 
 // Validate dynamic exercises generated from story content
-async function validateDynamicExercise(submission: any) {
+async function validateDynamicExercise(submission: ExerciseSubmission) {
   // For dynamic exercises, we need to reconstruct the correct answer
   // This is a simplified implementation
 
@@ -217,7 +212,7 @@ async function validateDynamicExercise(submission: any) {
 }
 
 // Validate database exercises
-async function validateDatabaseExercise(submission: unknown) {
+async function validateDatabaseExercise(submission: ExerciseSubmission) {
   const question = await prisma.question.findUnique({
     where: { id: submission.questionId },
     include: {


### PR DESCRIPTION
## Summary
- add ExerciseSubmission interface describing exercise submission fields
- update validation helpers to use ExerciseSubmission type
- adapt submission handling to the new interface

## Testing
- `npm test` *(fails: 7 failed, 6 passed, 13 total)*
- `npm run lint` *(fails: requires forbid require imports in tests, other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689fd739e5cc83299ad35a029147ac6d