### PR TITLE
refactor: add generics to service worker messaging

### DIFF
--- a/src/app/learning/hooks/useOfflineManager.ts
+++ b/src/app/learning/hooks/useOfflineManager.ts
@@ -81,11 +81,12 @@ export function useOfflineManager() {
     if (!offlineStatus.isServiceWorkerReady) return null;
 
     try {
-      const response = await sendMessageToServiceWorker({
+      const cacheStatus = await sendMessageToServiceWorker<
+        { type: "GET_CACHE_STATUS" },
+        CacheStatus
+      >({
         type: "GET_CACHE_STATUS",
       });
-
-      const cacheStatus = response as CacheStatus;
       setOfflineStatus((prev) => ({ ...prev, cacheStatus }));
       return cacheStatus;
     } catch (error) {
@@ -125,7 +126,7 @@ export function useOfflineManager() {
           throw new Error("Failed to fetch story data");
         }
 
-        const storyData = await storyResponse.json();
+        const storyData: LearningStory = await storyResponse.json();
 
         // Update progress
         setDownloadQueue((prev) =>
@@ -135,7 +136,10 @@ export function useOfflineManager() {
         );
 
         // Cache the story data
-        await sendMessageToServiceWorker({
+        await sendMessageToServiceWorker<
+          { type: "CACHE_STORY"; data: LearningStory },
+          { success: boolean; error?: string }
+        >({
           type: "CACHE_STORY",
           data: storyData,
         });
@@ -149,7 +153,13 @@ export function useOfflineManager() {
 
         // Download and cache audio if available
         if (storyData.audioUrl) {
-          await sendMessageToServiceWorker({
+          await sendMessageToServiceWorker<
+            {
+              type: "CACHE_AUDIO";
+              data: { url: string; storyId: string };
+            },
+            { success: boolean; error?: string }
+          >({
             type: "CACHE_AUDIO",
             data: { url: storyData.audioUrl, storyId: story.id },
           });
@@ -167,7 +177,13 @@ export function useOfflineManager() {
           for (const vocab of storyData.vocabularies) {
             if (vocab.audioUrl) {
               try {
-                await sendMessageToServiceWorker({
+                await sendMessageToServiceWorker<
+                  {
+                    type: "CACHE_AUDIO";
+                    data: { url: string; word: string };
+                  },
+                  { success: boolean; error?: string }
+                >({
                   type: "CACHE_AUDIO",
                   data: { url: vocab.audioUrl, word: vocab.word },
                 });
@@ -245,7 +261,15 @@ export function useOfflineManager() {
       if (!offlineStatus.isServiceWorkerReady) return false;
 
       try {
-        await sendMessageToServiceWorker({
+        await sendMessageToServiceWorker<
+          {
+            type: "CLEAR_CACHE";
+            data: {
+              cacheType: "stories" | "audio" | "api" | "all";
+            };
+          },
+          { success: boolean }
+        >({
           type: "CLEAR_CACHE",
           data: { cacheType },
         });
@@ -302,19 +326,21 @@ export function useOfflineManager() {
 }
 
 // Helper function to send messages to service worker
-async function sendMessageToServiceWorker(message: any): Promise<any> {
+async function sendMessageToServiceWorker<TRequest, TResponse>(
+  message: TRequest
+): Promise<TResponse> {
   if (!navigator.serviceWorker.controller) {
     throw new Error("No service worker controller available");
   }
 
-  return new Promise((resolve, reject) => {
+  return new Promise<TResponse>((resolve, reject) => {
     const messageChannel = new MessageChannel();
 
     messageChannel.port1.onmessage = (event) => {
-      if (event.data.error) {
-        reject(new Error(event.data.error));
+      if ((event.data as any)?.error) {
+        reject(new Error((event.data as any).error));
       } else {
-        resolve(event.data);
+        resolve(event.data as TResponse);
       }
     };
 


### PR DESCRIPTION
## Summary
- add generic request/response typing to `sendMessageToServiceWorker`
- cast service worker replies to the specified response type
- update message calls to specify request and response generics

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 6 passed)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fd73e0d248329b003bfd33d884417