### PR TITLE
refactor: type error boundary and exercise results

### DIFF
--- a/src/app/learning/components/LearningApp.tsx
+++ b/src/app/learning/components/LearningApp.tsx
@@ -3,11 +3,19 @@ import { logger } from '@/lib/logger';
 
 import React, { useState, useEffect, Suspense } from "react";
 // Error boundary implementation (simplified)
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  FallbackComponent: React.ComponentType<{
+    error: Error;
+    resetErrorBoundary: () => void;
+  }>;
+}
+
 class ErrorBoundary extends React.Component<
-  { children: React.ReactNode; FallbackComponent: React.ComponentType<any> },
+  ErrorBoundaryProps,
   { hasError: boolean; error?: Error }
 > {
-  constructor(props: any) {
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
   }
@@ -55,12 +63,13 @@ import type {
   LearningStory,
   Exercise,
   VocabularyData,
+  ExerciseResult,
 } from "../types/learning";
 
 interface LearningAppProps {
   story: LearningStory;
   onStoryComplete?: (storyId: string) => void;
-  onExerciseComplete?: (results: any[]) => void;
+  onExerciseComplete?: (results: ExerciseResult[]) => void;
   className?: string;
 }
 
@@ -167,7 +176,7 @@ export const LearningApp = React.memo(function LearningApp({
     onStoryComplete?.(story.id);
   };
 
-  const handleExerciseComplete = (results: unknown[]) => {
+  const handleExerciseComplete = (results: ExerciseResult[]) => {
     onExerciseComplete?.(results);
     setActivePanel("progress");
   };


### PR DESCRIPTION
## Summary
- add `ErrorBoundaryProps` and use it in `ErrorBoundary`
- type `onExerciseComplete` with `ExerciseResult[]`

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider; window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fd9d084308329a8dbba9b82cf05ce