### PR TITLE
refactor: type delete progress mutation variables

### DIFF
--- a/src/features/progress/hooks.ts
+++ b/src/features/progress/hooks.ts
@@ -33,6 +33,11 @@ export interface ListProgressParams {
   status?: ProgressStatusType;
 }
 
+export type DeleteProgressParams = {
+  id: string;
+  lessonId?: string;
+};
+
 export const buildLessonProgressQuery = (lessonId: string) =>
   queryOptions({
     queryKey: keyFactory.detail("user-progress", lessonId),
@@ -110,17 +115,17 @@ export function useDeleteProgress() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id }: { id: string }) =>
+    mutationFn: ({ id }: DeleteProgressParams) =>
       api(`/api/progress/${id}`, { method: "DELETE" }),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
         queryKey: keyFactory.list("user-progress"),
       });
-      if ((variables as any).lessonId) {
+      if (variables.lessonId) {
         queryClient.invalidateQueries({
           queryKey: keyFactory.detail(
             "user-progress",
-            (variables as any).lessonId as string
+            variables.lessonId
           ),
         });
       }


### PR DESCRIPTION
## Summary
- add DeleteProgressParams type to include optional lessonId
- remove any casts in useDeleteProgress and access variables.lessonId safely

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*
- `npm run lint` *(fails: @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_689fd9cf9058832989e4c7a14d31c045