### PR TITLE
feat(learning): add progress analytics types

### DIFF
--- a/src/features/learning/hooks.ts
+++ b/src/features/learning/hooks.ts
@@ -15,6 +15,8 @@ import type {
   VocabularyLookupData,
   SubmitExerciseData,
   ExerciseResult,
+  ProgressAnalytics,
+  VocabularyUpdate,
 } from "./types";
 import type { DifficultyLevel, StoryType } from "@prisma/client";
 
@@ -102,7 +104,10 @@ export const buildProgressAnalyticsQuery = (
     queryKey: keyFactory.list("progress-analytics", { timeframe }),
     queryFn: ({ signal }) => {
       const params = timeframe ? `?timeframe=${timeframe}` : "";
-      return api<any>(`/api/learning/progress/analytics${params}`, { signal });
+      return api<ProgressAnalytics>(
+        `/api/learning/progress/analytics${params}`,
+        { signal }
+      );
     },
     staleTime: 5 * 60_000,
     gcTime: 15 * 60_000,
@@ -187,7 +192,7 @@ export function useSyncOfflineData() {
   return useMutation({
     mutationFn: (data: {
       progressUpdates: UpdateProgressData[];
-      vocabularyUpdates: any[];
+      vocabularyUpdates: VocabularyUpdate[];
     }) =>
       api("/api/learning/sync", {
         method: "POST",

--- a/src/features/learning/types.ts
+++ b/src/features/learning/types.ts
@@ -154,3 +154,65 @@ export interface SubmitExerciseData {
   userAnswer: string | string[];
   timeSpent: number;
 }
+
+export interface VocabularyUpdate {
+  word: string;
+  status: "learning" | "mastered";
+  storyId?: string;
+}
+
+export interface ProgressAnalytics {
+  period: string;
+  dateRange: {
+    start: Date;
+    end: Date;
+  };
+  summary: {
+    totalSessions: number;
+    totalTimeSpent: number;
+    totalInteractions: number;
+    activeDays: number;
+    averageSessionTime: number;
+    lessonsCompleted: number;
+    lessonsInProgress: number;
+    vocabularyReviewed: number;
+    vocabularyMastered: number;
+  };
+  timeAnalysis: {
+    hourlyDistribution: number[];
+    dailyDistribution: number[];
+    peakLearningHour: number;
+    peakLearningDay: string;
+    totalTimeByHour: number;
+    averageSessionsPerDay: number;
+  };
+  difficultyAnalysis: Record<
+    DifficultyLevel,
+    { sessions: number; timeSpent: number; completed: number }
+  >;
+  vocabularyAnalysis: {
+    statusDistribution: Record<VocabularyStatus, number>;
+    difficultyDistribution: Record<DifficultyLevel, number>;
+    totalWords: number;
+    masteryRate: number;
+  };
+  learningPatterns: {
+    consistency: number;
+    preferredSessionLength: number;
+    learningVelocity: number;
+  };
+  recommendations: {
+    type: string;
+    title: string;
+    description: string;
+    priority: "low" | "medium" | "high";
+  }[];
+  comparison?: {
+    period: string;
+    dateRange: {
+      start: Date;
+      end: Date;
+    };
+    summary: ProgressAnalytics["summary"];
+  };
+}


### PR DESCRIPTION
## Summary
- define ProgressAnalytics interface for analytics endpoint
- add VocabularyUpdate interface for offline sync
- update learning hooks to use new analytics and vocabulary types

## Testing
- `npm test` (fails: window.matchMedia is not a function)
- `npm run lint` (fails: A `require()` style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689fd9cfcc608329afe2e3c32a83eb27