### PR TITLE
refactor: improve prisma typing in API routes

### DIFF
--- a/src/app/api/permissions/route.ts
+++ b/src/app/api/permissions/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
@@ -17,7 +18,7 @@ export async function GET(request: NextRequest) {
   const resource = searchParams.get("resource") || undefined;
   const action = searchParams.get("action") || undefined;
 
-  const where: any = {};
+  const where: Prisma.PermissionWhereInput = {};
   if (q) {
     where.OR = [
       { name: { contains: q, mode: "insensitive" } },

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
@@ -17,15 +18,11 @@ export async function GET(request: NextRequest) {
   const resource = searchParams.get("resource") || undefined;
   const tenantId = searchParams.get("tenantId") || undefined;
 
-  // optional repo access to compile even if model not generated yet
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
-  if (!repo) return NextResponse.json({ data: [], success: true, meta: { total: 0 } });
-
-  const where: any = {};
+  const where: Prisma.ResourcePolicyWhereInput = {};
   if (resource) where.resource = resource;
   if (tenantId) where.tenantId = tenantId;
 
-  const items = await repo.findMany({
+  const items = await prisma.resourcePolicy.findMany({
     where,
     orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
     take: 200,
@@ -49,10 +46,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "name, resource and effect are required" }, { status: 400 });
   }
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
-  if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
-
-  const created = await repo.create({
+  const created = await prisma.resourcePolicy.create({
     data: {
       name: String(name),
       resource: String(resource),

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { caslGuard, RequiredRule } from "@/core/auth/casl.guard";
 import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
@@ -32,7 +33,7 @@ export async function GET(request: NextRequest) {
     const lessonId = searchParams.get("lessonId");
 
     // Build where clause
-    const where: any = {};
+    const where: Prisma.QuizWhereInput = {};
 
     if (search) {
       where.OR = [

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
@@ -15,7 +16,7 @@ export async function GET(request: NextRequest) {
   const slug = searchParams.get("slug") || undefined;
   const tenantScope = searchParams.get("tenantScope") || undefined;
 
-  const where: any = {};
+  const where: Prisma.RoleWhereInput = {};
   if (q) {
     where.OR = [
       { name: { contains: q, mode: "insensitive" } },

--- a/src/app/api/stories/route.ts
+++ b/src/app/api/stories/route.ts
@@ -6,7 +6,7 @@ import { generateStoryChunks, calculateStoryStats } from "@/lib/story-chunker";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
 import { z } from "zod";
-import { StoryType, DifficultyLevel } from "@prisma/client";
+import { StoryType, DifficultyLevel, Prisma } from "@prisma/client";
 
 const storySchema = z.object({
   title: z.string().min(1),
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
     const skip = (page - 1) * limit;
 
     // Build where clause for search
-    const where: any = {};
+    const where: Prisma.StoryWhereInput = {};
 
     if (search) {
       where.OR = [


### PR DESCRIPTION
## Summary
- use Prisma `WhereInput` types for API where clauses
- call `prisma.resourcePolicy` directly without casting

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, etc.)*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fe0a4d4bc8329995a6b2ca808752b