### PR TITLE
refactor: strengthen validation typing

### DIFF
--- a/src/config/api/validation.ts
+++ b/src/config/api/validation.ts
@@ -102,15 +102,15 @@ export const USER_VALIDATION_RULES: ValidationRules = {
 };
 
 // Validation Helper Functions
-export function validateField(value: any, rule: ValidationRule): string[] {
+export function validateField(value: unknown, rule: ValidationRule): string[] {
   const errors: string[] = [];
 
-  if (rule.required && (value === undefined || value === null || value === '')) {
+  if (rule.required && (value === undefined || value === null || (typeof value === 'string' && value === ''))) {
     errors.push('This field is required');
     return errors;
   }
 
-  if (value === undefined || value === null || value === '') {
+  if (value === undefined || value === null || (typeof value === 'string' && value === '')) {
     return errors; // Skip other validations if not required and empty
   }
 
@@ -135,14 +135,16 @@ export function validateField(value: any, rule: ValidationRule): string[] {
     }
   }
 
-  if (rule.enum && !rule.enum.includes(value)) {
-    errors.push(`Must be one of: ${rule.enum.join(', ')}`);
+  if (rule.enum) {
+    if (typeof value !== 'string' || !rule.enum.includes(value)) {
+      errors.push(`Must be one of: ${rule.enum.join(', ')}`);
+    }
   }
 
   return errors;
 }
 
-export function validateObject(obj: Record<string, any>, rules: ValidationRules): Record<string, string[]> {
+export function validateObject(obj: Record<string, unknown>, rules: ValidationRules): Record<string, string[]> {
   const errors: Record<string, string[]> = {};
 
   for (const [field, rule] of Object.entries(rules)) {


### PR DESCRIPTION
## Summary
- tighten validation helpers by accepting `unknown`
- perform runtime type guards for string enums

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fe0a4fe188329a76c1e5093a92c36