### PR TITLE
refactor: strengthen API error typings

### DIFF
--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -240,9 +240,16 @@ class ApiClient {
 
       if (!response.ok) {
         type ErrorBody = { message?: string; error?: string; [k: string]: unknown };
-        const obj = (typeof body === "object" && body !== null) ? (body as ErrorBody) : undefined;
+        const obj = (typeof body === "object" && body !== null)
+          ? (body as ErrorBody)
+          : undefined;
         const message = obj?.message || obj?.error || `HTTP ${response.status}`;
-        throw new ApiError(message, response.status, body, `HTTP_${response.status}`);
+        throw new ApiError<ErrorBody | undefined>(
+          message,
+          response.status,
+          obj,
+          `HTTP_${response.status}`
+        );
       }
 
       return (body as T) ?? (await response.text() as unknown as T);

--- a/src/core/api/errorHandling.ts
+++ b/src/core/api/errorHandling.ts
@@ -1,9 +1,9 @@
 // Enhanced error handling with custom error types
-export class ApiError extends Error {
+export class ApiError<T = unknown> extends Error {
   constructor(
     message: string,
     public status: number,
-    public body?: any,
+    public body?: T,
     public code?: string
   ) {
     super(message);
@@ -18,11 +18,11 @@ export class NetworkError extends Error {
   }
 }
 
-export class ValidationError extends Error {
+export class ValidationError<T = unknown> extends Error {
   constructor(
     message: string,
     public field?: string,
-    public value?: any
+    public value?: T
   ) {
     super(message);
     this.name = 'ValidationError';
@@ -48,7 +48,7 @@ export const retryConfig = {
 // Global error handler
 export const handleApiError = (error: unknown): never => {
   if (error instanceof Response) {
-    throw new ApiError(
+    throw new ApiError<undefined>(
       `HTTP ${error.status}`,
       error.status,
       undefined,
@@ -64,7 +64,7 @@ export const handleApiError = (error: unknown): never => {
     throw error;
   }
   
-  throw new ApiError('Unknown error occurred', 500, error, 'UNKNOWN_ERROR');
+  throw new ApiError<unknown>('Unknown error occurred', 500, error, 'UNKNOWN_ERROR');
 };
 
 // Error boundary helper


### PR DESCRIPTION
## Summary
- add generics to ApiError and ValidationError and replace `any` with `unknown`
- propagate typed error bodies in ApiClient

## Testing
- `npm test` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*
- `npm run lint` *(fails: Error: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe0a7600083299c73bc1b3c817b62