### PR TITLE
refactor: add interfaces for learning analytics

### DIFF
--- a/src/app/api/learning/progress/analytics/route.ts
+++ b/src/app/api/learning/progress/analytics/route.ts
@@ -3,6 +3,47 @@ import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
+import type {
+  DifficultyLevel,
+  ProgressStatus,
+  VocabStatus,
+} from "@prisma/client";
+
+interface LearningSession {
+  timeSpentSec: number | null;
+  interactionCount: number | null;
+  startedAt: Date;
+  lesson?: {
+    id: string;
+    title: string;
+    difficulty: DifficultyLevel;
+  } | null;
+  story?: {
+    id: string;
+    title: string;
+    difficulty: DifficultyLevel;
+  } | null;
+}
+
+interface VocabularyProgress {
+  status: VocabStatus;
+  vocabulary?: {
+    word: string;
+    lesson?: {
+      difficulty: DifficultyLevel;
+    } | null;
+  } | null;
+}
+
+interface LessonProgress {
+  status: ProgressStatus;
+  lesson?: {
+    id: string;
+    title: string;
+    difficulty: DifficultyLevel;
+    estimatedMinutes: number | null;
+  } | null;
+}
 
 // GET /api/learning/progress/analytics - Get learning analytics and insights
 export async function GET(request: NextRequest) {
@@ -36,7 +77,8 @@ export async function GET(request: NextRequest) {
     const dateRanges = calculateDateRanges(period, now);
 
     // Get learning sessions data
-    const currentPeriodSessions = await prisma.learningSession.findMany({
+    const currentPeriodSessions: LearningSession[] =
+      await prisma.learningSession.findMany({
       where: {
         userId: user.id,
         startedAt: {
@@ -63,7 +105,8 @@ export async function GET(request: NextRequest) {
     });
 
     // Get vocabulary progress data
-    const vocabularyProgress = await prisma.userVocabularyProgress.findMany({
+    const vocabularyProgress: VocabularyProgress[] =
+      await prisma.userVocabularyProgress.findMany({
       where: {
         userId: user.id,
         lastReviewed: {
@@ -86,7 +129,8 @@ export async function GET(request: NextRequest) {
     });
 
     // Get lesson progress data
-    const lessonProgress = await prisma.userProgress.findMany({
+    const lessonProgress: LessonProgress[] =
+      await prisma.userProgress.findMany({
       where: {
         userId: user.id,
         updatedAt: {
@@ -131,7 +175,8 @@ export async function GET(request: NextRequest) {
 
     // Add comparison data if requested
     if (includeComparison) {
-      const previousPeriodSessions = await prisma.learningSession.findMany({
+      const previousPeriodSessions: LearningSession[] =
+        await prisma.learningSession.findMany({
         where: {
           userId: user.id,
           startedAt: {
@@ -141,7 +186,7 @@ export async function GET(request: NextRequest) {
         },
       });
 
-      const previousVocabularyProgress =
+      const previousVocabularyProgress: VocabularyProgress[] =
         await prisma.userVocabularyProgress.findMany({
           where: {
             userId: user.id,
@@ -152,7 +197,8 @@ export async function GET(request: NextRequest) {
           },
         });
 
-      const previousLessonProgress = await prisma.userProgress.findMany({
+      const previousLessonProgress: LessonProgress[] =
+        await prisma.userProgress.findMany({
         where: {
           userId: user.id,
           updatedAt: {
@@ -220,9 +266,9 @@ function calculateDateRanges(period: string, now: Date) {
 
 // Calculate summary statistics
 function calculateSummaryStats(
-  sessions: any[],
-  vocabularyProgress: any[],
-  lessonProgress: any[]
+  sessions: LearningSession[],
+  vocabularyProgress: VocabularyProgress[],
+  lessonProgress: LessonProgress[]
 ) {
   const totalTimeSpent = sessions.reduce(
     (sum, session) => sum + (session.timeSpentSec || 0),
@@ -255,7 +301,7 @@ function calculateSummaryStats(
 }
 
 // Calculate time-based analysis
-function calculateTimeAnalysis(sessions: any[]) {
+function calculateTimeAnalysis(sessions: LearningSession[]) {
   const hourlyDistribution = new Array(24).fill(0);
   const dailyDistribution = new Array(7).fill(0);
 
@@ -298,7 +344,10 @@ function calculateTimeAnalysis(sessions: any[]) {
 }
 
 // Calculate difficulty-based analysis
-function calculateDifficultyAnalysis(sessions: any[], lessonProgress: any[]) {
+function calculateDifficultyAnalysis(
+  sessions: LearningSession[],
+  lessonProgress: LessonProgress[]
+) {
   const difficultyStats = {
     beginner: { sessions: 0, timeSpent: 0, completed: 0 },
     elementary: { sessions: 0, timeSpent: 0, completed: 0 },
@@ -328,7 +377,9 @@ function calculateDifficultyAnalysis(sessions: any[], lessonProgress: any[]) {
 }
 
 // Calculate vocabulary analysis
-function calculateVocabularyAnalysis(vocabularyProgress: any[]) {
+function calculateVocabularyAnalysis(
+  vocabularyProgress: VocabularyProgress[]
+) {
   const statusDistribution = {
     new: 0,
     reviewing: 0,
@@ -366,7 +417,7 @@ function calculateVocabularyAnalysis(vocabularyProgress: any[]) {
 }
 
 // Calculate learning patterns
-function calculateLearningPatterns(sessions: any[]) {
+function calculateLearningPatterns(sessions: LearningSession[]) {
   if (sessions.length === 0) {
     return {
       consistency: 0,
@@ -406,9 +457,9 @@ function calculateLearningPatterns(sessions: any[]) {
 
 // Generate personalized recommendations
 function generateRecommendations(
-  sessions: any[],
-  vocabularyProgress: any[],
-  lessonProgress: any[]
+  sessions: LearningSession[],
+  vocabularyProgress: VocabularyProgress[],
+  lessonProgress: LessonProgress[]
 ) {
   const recommendations = [];
 


### PR DESCRIPTION
## Summary
- define LearningSession, VocabularyProgress and LessonProgress interfaces
- type prisma queries and analytics helpers with new interfaces

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider; window.matchMedia is not a function)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe0a97a3c8329b4ab53b3f0787165