### PR TITLE
refactor: enforce serializable logger context

### DIFF
--- a/debug-env.js
+++ b/debug-env.js
@@ -39,5 +39,7 @@ const getBaseUrl = () => {
   return `${protocol}://${host}${port !== '80' && port !== '443' ? `:${port}` : ''}`;
 };
 
-logger.info('🌐 Constructed Base URL:', getBaseUrl());
-logger.info('🚀 Server should be running on:', `http://localhost:${process.env.PORT || '3002'}`);
+logger.info('🌐 Constructed Base URL:', { url: getBaseUrl() });
+logger.info('🚀 Server should be running on:', {
+  url: `http://localhost:${process.env.PORT || '3002'}`,
+});

--- a/middleware.ts
+++ b/middleware.ts
@@ -120,7 +120,7 @@ export function middleware(request: NextRequest) {
       return addSecurityHeaders(response);
     } catch (error) {
       // Invalid token, redirect to login
-      logger.error("Token verification failed:", error);
+      logger.error("Token verification failed:", undefined, error);
 
       return NextResponse.redirect(new URL("/login", request.url));
     }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -597,6 +597,6 @@ async function main() {
 
 main()
   .catch((e) => {
-    logger.error("❌ Seed failed:", e);
+    logger.error("❌ Seed failed:", undefined, e);
     process.exit(1);
   });

--- a/src/app/admin/quizzes/AdminQuizzesList.tsx
+++ b/src/app/admin/quizzes/AdminQuizzesList.tsx
@@ -44,7 +44,7 @@ export default function AdminQuizzesList() {
       await createMutation.mutateAsync(data);
       setShowCreateModal(false);
     } catch (error) {
-      logger.error("Error creating quiz:", error);
+      logger.error("Error creating quiz:", undefined, error);
     }
   };
 
@@ -56,7 +56,7 @@ export default function AdminQuizzesList() {
       setShowEditModal(false);
       setSelectedId(null);
     } catch (error) {
-      logger.error("Error updating quiz:", error);
+      logger.error("Error updating quiz:", undefined, error);
     }
   };
 
@@ -66,7 +66,7 @@ export default function AdminQuizzesList() {
     try {
       await deleteMutation.mutateAsync(id);
     } catch (error) {
-      logger.error("Error deleting quiz:", error);
+      logger.error("Error deleting quiz:", undefined, error);
     }
   };
 

--- a/src/app/admin/stories/AdminStoriesList.tsx
+++ b/src/app/admin/stories/AdminStoriesList.tsx
@@ -61,7 +61,7 @@ export default function AdminStoriesList() {
       await createMutation.mutateAsync(data);
       setShowCreateModal(false);
     } catch (error) {
-      logger.error("Error creating story:", error);
+      logger.error("Error creating story:", undefined, error);
     }
   };
 
@@ -73,7 +73,7 @@ export default function AdminStoriesList() {
       setShowEditModal(false);
       setSelectedId(null);
     } catch (error) {
-      logger.error("Error updating story:", error);
+      logger.error("Error updating story:", undefined, error);
     }
   };
 
@@ -83,7 +83,7 @@ export default function AdminStoriesList() {
     try {
       await deleteMutation.mutateAsync(id);
     } catch (error) {
-      logger.error("Error deleting story:", error);
+      logger.error("Error deleting story:", undefined, error);
     }
   };
 

--- a/src/app/admin/stories/AdminStoriesManagement.tsx
+++ b/src/app/admin/stories/AdminStoriesManagement.tsx
@@ -76,7 +76,7 @@ export default function AdminStoriesManagement() {
       await createMutation.mutateAsync(data);
       setShowCreateModal(false);
     } catch (error) {
-      logger.error("Error creating story:", error);
+      logger.error("Error creating story:", undefined, error);
     }
   };
 
@@ -86,7 +86,7 @@ export default function AdminStoriesManagement() {
       await updateMutation.mutateAsync({ id: editingStory.id, data });
       setEditingStory(null);
     } catch (error) {
-      logger.error("Error updating story:", error);
+      logger.error("Error updating story:", undefined, error);
     }
   };
 
@@ -95,7 +95,7 @@ export default function AdminStoriesManagement() {
     try {
       await deleteMutation.mutateAsync(id);
     } catch (error) {
-      logger.error("Error deleting story:", error);
+      logger.error("Error deleting story:", undefined, error);
     }
   };
 
@@ -106,7 +106,7 @@ export default function AdminStoriesManagement() {
       setSelectedIds([]);
       setShowBulkActions(false);
     } catch (error) {
-      logger.error("Error bulk updating stories:", error);
+      logger.error("Error bulk updating stories:", undefined, error);
     }
   };
 
@@ -118,7 +118,7 @@ export default function AdminStoriesManagement() {
       setSelectedIds([]);
       setShowBulkActions(false);
     } catch (error) {
-      logger.error("Error bulk deleting stories:", error);
+      logger.error("Error bulk deleting stories:", undefined, error);
     }
   };
 

--- a/src/app/admin/users/AdminUserList.tsx
+++ b/src/app/admin/users/AdminUserList.tsx
@@ -47,7 +47,7 @@ export default function AdminUserList() {
       setShowCreateForm(false);
       setFormData({ name: "", email: "", role: "student" });
     } catch (error) {
-      logger.error("Error creating user:", error);
+      logger.error("Error creating user:", undefined, error);
     }
   };
 
@@ -63,7 +63,7 @@ export default function AdminUserList() {
       setEditingUser(null);
       setFormData({ name: "", email: "", role: "student" });
     } catch (error) {
-      logger.error("Error updating user:", error);
+      logger.error("Error updating user:", undefined, error);
     }
   };
 
@@ -74,7 +74,7 @@ export default function AdminUserList() {
       try {
         await deleteUser.mutateAsync(user.id);
       } catch (error) {
-        logger.error("Error deleting user:", error);
+        logger.error("Error deleting user:", undefined, error);
       }
     }
   };

--- a/src/app/admin/vocabularies/AdminVocabulariesList.tsx
+++ b/src/app/admin/vocabularies/AdminVocabulariesList.tsx
@@ -41,7 +41,7 @@ export default function AdminVocabulariesList() {
       await createMutation.mutateAsync(data);
       setShowCreateModal(false);
     } catch (error) {
-      logger.error("Error creating vocabulary:", error);
+      logger.error("Error creating vocabulary:", undefined, error);
     }
   };
 
@@ -53,7 +53,7 @@ export default function AdminVocabulariesList() {
       setShowEditModal(false);
       setSelectedId(null);
     } catch (error) {
-      logger.error("Error updating vocabulary:", error);
+      logger.error("Error updating vocabulary:", undefined, error);
     }
   };
 
@@ -63,7 +63,7 @@ export default function AdminVocabulariesList() {
     try {
       await deleteMutation.mutateAsync(id);
     } catch (error) {
-      logger.error("Error deleting vocabulary:", error);
+      logger.error("Error deleting vocabulary:", undefined, error);
     }
   };
 

--- a/src/app/api/learning/progress/audio/route.ts
+++ b/src/app/api/learning/progress/audio/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: NextRequest) {
         ? JSON.parse(progress.metadata as string).bookmarks || []
         : [];
     } catch (error) {
-      logger.error("Error parsing bookmarks:", error);
+      logger.error("Error parsing bookmarks:", undefined, error);
     }
 
     return NextResponse.json({
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
       lastUpdated: progress.updatedAt,
     });
   } catch (error) {
-    logger.error("Error fetching audio progress:", error);
+    logger.error("Error fetching audio progress:", undefined, error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
@@ -120,7 +120,7 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
-    logger.error("Error saving audio progress:", error);
+    logger.error("Error saving audio progress:", undefined, error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }
@@ -156,7 +156,7 @@ export async function DELETE(request: NextRequest) {
 
     return NextResponse.json({ success: true });
   } catch (error) {
-    logger.error("Error clearing audio progress:", error);
+    logger.error("Error clearing audio progress:", undefined, error);
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 }

--- a/src/app/learning/components/AudioPlayer.tsx
+++ b/src/app/learning/components/AudioPlayer.tsx
@@ -197,7 +197,7 @@ export const AudioPlayer = React.memo(function AudioPlayer({
       progressActions.updatePosition(audio.currentTime);
     } else {
       audio.play().catch((error) => {
-        logger.error("Error playing audio:", error);
+        logger.error("Error playing audio:", undefined, error);
         setAudioState((prev) => ({
           ...prev,
           error: "Không thể phát âm thanh",

--- a/src/app/learning/components/DownloadManager.tsx
+++ b/src/app/learning/components/DownloadManager.tsx
@@ -61,7 +61,7 @@ export function DownloadManager({ stories, className }: DownloadManagerProps) {
         try {
           await downloadStory(story);
         } catch (error) {
-          logger.error(`Failed to download story ${storyId}:`, error);
+          logger.error(`Failed to download story ${storyId}:`, undefined, error);
         }
       }
     }

--- a/src/app/learning/components/LearningApp.tsx
+++ b/src/app/learning/components/LearningApp.tsx
@@ -129,7 +129,7 @@ export const LearningApp = React.memo(function LearningApp({
           setExercises(data.exercises || []);
         }
       } catch (error) {
-        logger.error("Failed to load exercises:", error);
+        logger.error("Failed to load exercises:", undefined, error);
       }
     };
 
@@ -153,7 +153,7 @@ export const LearningApp = React.memo(function LearningApp({
         setVocabularyPopup((prev) => (prev ? { ...prev, data } : null));
       }
     } catch (error) {
-      logger.error("Failed to load vocabulary data:", error);
+      logger.error("Failed to load vocabulary data:", undefined, error);
     }
   };
 

--- a/src/app/learning/components/StoryReaderContainer.tsx
+++ b/src/app/learning/components/StoryReaderContainer.tsx
@@ -78,7 +78,7 @@ export function StoryReaderContainer({
       try {
         await submitExerciseResult(result);
       } catch (error) {
-        logger.error("Failed to submit exercise result:", error);
+        logger.error("Failed to submit exercise result:", undefined, error);
       }
     },
     [submitExerciseResult]

--- a/src/app/learning/hooks/useAudioPlayer.ts
+++ b/src/app/learning/hooks/useAudioPlayer.ts
@@ -153,7 +153,7 @@ export function useAudioPlayer({
       await audio.play();
       setState((prev) => ({ ...prev, isPlaying: true }));
     } catch (error) {
-      logger.error("Error playing audio:", error);
+      logger.error("Error playing audio:", undefined, error);
       setState((prev) => ({
         ...prev,
         error: "Không thể phát âm thanh",

--- a/src/app/learning/hooks/useAudioProgress.ts
+++ b/src/app/learning/hooks/useAudioProgress.ts
@@ -94,7 +94,7 @@ export function useAudioProgress({
           // Continue with local data only
         }
       } catch (error) {
-        logger.error("Error loading audio progress:", error);
+        logger.error("Error loading audio progress:", undefined, error);
         setError("Không thể tải tiến độ âm thanh");
       } finally {
         setIsLoading(false);
@@ -135,7 +135,7 @@ export function useAudioProgress({
 
         setError(null);
       } catch (error) {
-        logger.error("Error saving audio progress:", error);
+        logger.error("Error saving audio progress:", undefined, error);
         setError("Không thể lưu tiến độ âm thanh");
       }
     },

--- a/src/app/learning/hooks/useDataSync.ts
+++ b/src/app/learning/hooks/useDataSync.ts
@@ -243,7 +243,7 @@ export function useDataSync(userId: string) {
           result.syncedItems.learningProgress = true;
         }
       } catch (error) {
-        logger.error("Failed to sync learning progress:", error);
+        logger.error("Failed to sync learning progress:", undefined, error);
       }
     }
 
@@ -272,7 +272,7 @@ export function useDataSync(userId: string) {
           result.syncedItems.vocabularyProgress = merged.length;
         }
       } catch (error) {
-        logger.error("Failed to sync vocabulary progress:", error);
+        logger.error("Failed to sync vocabulary progress:", undefined, error);
       }
     }
 
@@ -288,7 +288,7 @@ export function useDataSync(userId: string) {
         await uploadExerciseResults(pendingData.exerciseResults);
         result.syncedItems.exerciseResults = pendingData.exerciseResults.length;
       } catch (error) {
-        logger.error("Failed to sync exercise results:", error);
+        logger.error("Failed to sync exercise results:", undefined, error);
       }
     }
 
@@ -310,7 +310,7 @@ export function useDataSync(userId: string) {
         await uploadLearningStats(mergedStats);
         result.syncedItems.learningStats = true;
       } catch (error) {
-        logger.error("Failed to sync learning stats:", error);
+        logger.error("Failed to sync learning stats:", undefined, error);
       }
     }
 
@@ -325,7 +325,7 @@ export function useDataSync(userId: string) {
       try {
         await uploadLearningSessions(pendingData.sessions);
       } catch (error) {
-        logger.error("Failed to sync learning sessions:", error);
+        logger.error("Failed to sync learning sessions:", undefined, error);
       }
     }
 

--- a/src/app/learning/hooks/useExercises.ts
+++ b/src/app/learning/hooks/useExercises.ts
@@ -33,7 +33,7 @@ export function useExercises(storyId: string): UseExercisesReturn {
       const data = await response.json();
       setExercises(data.exercises || []);
     } catch (err) {
-      logger.error("Error fetching exercises:", err);
+      logger.error("Error fetching exercises:", undefined, err);
       setError(err instanceof Error ? err.message : "Failed to load exercises");
 
       // Fallback to mock exercises for development
@@ -67,7 +67,7 @@ export function useExercises(storyId: string): UseExercisesReturn {
       const data = await response.json();
       logger.info("Exercise result submitted:", data);
     } catch (err) {
-      logger.error("Error submitting exercise result:", err);
+      logger.error("Error submitting exercise result:", undefined, err);
       // Don't throw error to avoid breaking user experience
       // Results will be cached locally and can be synced later
     }

--- a/src/app/learning/hooks/useOfflineManager.ts
+++ b/src/app/learning/hooks/useOfflineManager.ts
@@ -53,7 +53,7 @@ export function useOfflineManager() {
           getCacheStatus();
         })
         .catch((error) => {
-          logger.error("Service Worker registration failed:", error);
+          logger.error("Service Worker registration failed:", undefined, error);
         });
     }
   }, []);
@@ -90,7 +90,7 @@ export function useOfflineManager() {
       setOfflineStatus((prev) => ({ ...prev, cacheStatus }));
       return cacheStatus;
     } catch (error) {
-      logger.error("Failed to get cache status:", error);
+      logger.error("Failed to get cache status:", undefined, error);
       return null;
     }
   }, [offlineStatus.isServiceWorkerReady]);
@@ -196,7 +196,7 @@ export function useOfflineManager() {
 
         return true;
       } catch (error) {
-        logger.error("Failed to download story:", error);
+        logger.error("Failed to download story:", undefined, error);
 
         setDownloadQueue((prev) =>
           prev.map((item) =>
@@ -256,7 +256,7 @@ export function useOfflineManager() {
 
         return true;
       } catch (error) {
-        logger.error("Failed to clear cache:", error);
+        logger.error("Failed to clear cache:", undefined, error);
         return false;
       }
     },
@@ -272,7 +272,7 @@ export function useOfflineManager() {
       // For now, we'll return an empty array
       return [];
     } catch (error) {
-      logger.error("Failed to get offline stories:", error);
+      logger.error("Failed to get offline stories:", undefined, error);
       return [];
     }
   }, [offlineStatus.cacheStatus]);

--- a/src/app/learning/hooks/useOfflineProgress.ts
+++ b/src/app/learning/hooks/useOfflineProgress.ts
@@ -89,7 +89,7 @@ export function useOfflineProgress(userId: string) {
         pendingSync: pendingSync === "true",
       });
     } catch (error) {
-      logger.error("Failed to load offline progress data:", error);
+      logger.error("Failed to load offline progress data:", undefined, error);
     }
   }, []);
 
@@ -120,7 +120,7 @@ export function useOfflineProgress(userId: string) {
         offlineData.pendingSync.toString()
       );
     } catch (error) {
-      logger.error("Failed to save offline progress data:", error);
+      logger.error("Failed to save offline progress data:", undefined, error);
     }
   }, [offlineData]);
 

--- a/src/app/learning/hooks/useProgress.ts
+++ b/src/app/learning/hooks/useProgress.ts
@@ -65,7 +65,7 @@ export function useProgress({
         setStats(statsData);
       }
     } catch (err) {
-      logger.error("Error loading progress:", err);
+      logger.error("Error loading progress:", undefined, err);
       setError("Không thể tải tiến độ học tập");
 
       // Load from localStorage as fallback
@@ -87,7 +87,7 @@ export function useProgress({
         setStats(data.stats);
       }
     } catch (err) {
-      logger.error("Error loading from localStorage:", err);
+      logger.error("Error loading from localStorage:", undefined, err);
     }
   }, [userId]);
 
@@ -103,7 +103,7 @@ export function useProgress({
       };
       localStorage.setItem(`learning-progress-${userId}`, JSON.stringify(data));
     } catch (err) {
-      logger.error("Error saving to localStorage:", err);
+      logger.error("Error saving to localStorage:", undefined, err);
     }
   }, [userId, progress, vocabularyProgress, levelProgress, stats]);
 
@@ -135,7 +135,7 @@ export function useProgress({
           saveToLocalStorage();
         }
       } catch (err) {
-        logger.error("Error updating story completion:", err);
+        logger.error("Error updating story completion:", undefined, err);
       }
     },
     [userId, saveToLocalStorage]
@@ -175,7 +175,7 @@ export function useProgress({
           loadProgress();
         }
       } catch (err) {
-        logger.error("Error updating vocabulary progress:", err);
+        logger.error("Error updating vocabulary progress:", undefined, err);
       }
     },
     [userId, loadProgress]
@@ -262,7 +262,7 @@ export function useProgress({
           loadProgress();
         }
       } catch (err) {
-        logger.error("Error marking vocabulary as mastered:", err);
+        logger.error("Error marking vocabulary as mastered:", undefined, err);
       }
     },
     [userId, loadProgress]

--- a/src/app/learning/hooks/useStories.ts
+++ b/src/app/learning/hooks/useStories.ts
@@ -57,7 +57,7 @@ export function useStories(options: UseStoriesOptions = {}): UseStoriesReturn {
       const data = await response.json();
       setStories(data);
     } catch (err) {
-      logger.error("Error fetching stories:", err);
+      logger.error("Error fetching stories:", undefined, err);
       setError(
         err instanceof Error ? err.message : "Không thể tải danh sách truyện"
       );
@@ -102,7 +102,7 @@ export function useStory(storyId: string | null) {
       const data = await response.json();
       setStory(data);
     } catch (err) {
-      logger.error("Error fetching story:", err);
+      logger.error("Error fetching story:", undefined, err);
       setError(err instanceof Error ? err.message : "Không thể tải truyện");
       setStory(null);
     } finally {

--- a/src/app/learning/hooks/useUserPreferences.ts
+++ b/src/app/learning/hooks/useUserPreferences.ts
@@ -40,7 +40,7 @@ export function useUserPreferences() {
         setPreferences({ ...DEFAULT_PREFERENCES, ...parsed });
       }
     } catch (err) {
-      logger.error("Failed to load user preferences:", err);
+      logger.error("Failed to load user preferences:", undefined, err);
       setError("Không thể tải cài đặt người dùng");
     } finally {
       setIsLoading(false);
@@ -90,7 +90,7 @@ export function useUserPreferences() {
 
         return true;
       } catch (err) {
-        logger.error("Failed to save user preferences:", err);
+        logger.error("Failed to save user preferences:", undefined, err);
         setError("Không thể lưu cài đặt");
         return false;
       }

--- a/src/app/learning/hooks/useVocabulary.ts
+++ b/src/app/learning/hooks/useVocabulary.ts
@@ -55,7 +55,7 @@ export function useVocabulary(): UseVocabularyReturn {
 
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     } catch (err) {
-      logger.error("Error fetching vocabulary:", err);
+      logger.error("Error fetching vocabulary:", undefined, err);
       setError(
         err instanceof Error ? err.message : "Không thể tải định nghĩa từ vựng"
       );

--- a/src/app/learning/hooks/useVocabularyAudio.ts
+++ b/src/app/learning/hooks/useVocabularyAudio.ts
@@ -131,7 +131,7 @@ export function useVocabularyAudio(options: UseVocabularyAudioOptions = {}) {
           audio.removeEventListener("loadstart", handleLoadStart);
         }, 1000);
       } catch (error) {
-        logger.error("Error playing pronunciation:", error);
+        logger.error("Error playing pronunciation:", undefined, error);
 
         // Try fallback to text-to-speech
         if ("speechSynthesis" in window && audioUrl) {
@@ -202,7 +202,7 @@ export function useVocabularyAudio(options: UseVocabularyAudioOptions = {}) {
 
         audioCache.current.set(word, audio);
       } catch (error) {
-        logger.error("Error preloading audio:", error);
+        logger.error("Error preloading audio:", undefined, error);
       }
     },
     [cacheSize]

--- a/src/app/learning/utils/bundleOptimization.ts
+++ b/src/app/learning/utils/bundleOptimization.ts
@@ -269,7 +269,7 @@ export const serviceWorkerUtils = {
       logger.info("Service Worker registered successfully:", registration);
       return registration;
     } catch (error) {
-      logger.error("Service Worker registration failed:", error);
+      logger.error("Service Worker registration failed:", undefined, error);
       return null;
     }
   },
@@ -280,7 +280,7 @@ export const serviceWorkerUtils = {
       await registration.update();
       logger.info("Service Worker updated successfully");
     } catch (error) {
-      logger.error("Service Worker update failed:", error);
+      logger.error("Service Worker update failed:", undefined, error);
     }
   },
 

--- a/src/components/auth/TokenRefreshProvider.tsx
+++ b/src/components/auth/TokenRefreshProvider.tsx
@@ -24,7 +24,7 @@ export function TokenRefreshProvider({ children }: TokenRefreshProviderProps) {
       logger.info("🔄 Token refreshed successfully");
     },
     onRefreshError: (error) => {
-      logger.error("🔄 Token refresh failed:", error);
+      logger.error("🔄 Token refresh failed:", undefined, error);
     },
   });
 

--- a/src/components/debug/TokenDebugPanel.tsx
+++ b/src/components/debug/TokenDebugPanel.tsx
@@ -38,7 +38,7 @@ export function TokenDebugPanel() {
         logger.info('❌ Manual refresh failed');
       }
     } catch (error) {
-      logger.error('❌ Manual refresh error:', error);
+      logger.error('❌ Manual refresh error:', undefined, error);
     }
   };
 

--- a/src/core/auth/AbilityProvider.tsx
+++ b/src/core/auth/AbilityProvider.tsx
@@ -51,7 +51,7 @@ export default function AbilityProvider({
 
       return buildAbility(rules ?? undefined, context);
     } catch (error) {
-      logger.error('Error building ability in AbilityProvider:', error);
+      logger.error('Error building ability in AbilityProvider:', undefined, error);
       // Return a default ability with no permissions as fallback
       return buildAbility(undefined, undefined);
     }
@@ -80,7 +80,7 @@ export function useSafeAbility(): AppAbility | null {
   try {
     return useAbility();
   } catch (error) {
-    logger.error('Error accessing ability context:', error);
+    logger.error('Error accessing ability context:', undefined, error);
     return null;
   }
 }

--- a/src/core/auth/AuthContextBridge.tsx
+++ b/src/core/auth/AuthContextBridge.tsx
@@ -25,7 +25,7 @@ class AuthErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    logger.error("🚨 AuthContextBridge Error:", error, errorInfo);
+    logger.error("🚨 AuthContextBridge Error:", { errorInfo }, error);
   }
 
   render() {
@@ -105,7 +105,7 @@ export default function AuthContextBridge({
       </AuthErrorBoundary>
     );
   } catch (error) {
-    logger.error("🚨 AuthContextBridge Render Error:", error);
+    logger.error("🚨 AuthContextBridge Render Error:", undefined, error);
     return (
       <div
         style={{

--- a/src/core/auth/casl.guard.ts
+++ b/src/core/auth/casl.guard.ts
@@ -50,7 +50,7 @@ export function checkAbilities(
           failedRules.push(rule);
         }
       } catch (ruleError) {
-        logger.error(`Error checking rule ${rule.action}:${rule.subject}:`, ruleError);
+        logger.error(`Error checking rule ${rule.action}:${rule.subject}:`, undefined, ruleError as Error);
         failedRules.push(rule);
       }
     }
@@ -60,7 +60,7 @@ export function checkAbilities(
       failedRules
     };
   } catch (error) {
-    logger.error('Error in checkAbilities:', error);
+    logger.error('Error in checkAbilities:', undefined, error as Error);
     return {
       allowed: false,
       failedRules: rules
@@ -148,7 +148,9 @@ export async function caslGuardWithPolicies(
     return { allowed: true };
   } catch (policyErr) {
     if (process.env.NODE_ENV === "development") {
-      logger.warn("ABAC policy evaluation failed, continuing with RBAC only:", policyErr);
+      logger.warn("ABAC policy evaluation failed, continuing with RBAC only:", {
+        error: policyErr instanceof Error ? policyErr.message : String(policyErr),
+      });
     }
     return { allowed: true };
   }
@@ -223,7 +225,7 @@ export function caslGuard(
       : { allowed: false, error: "Insufficient permissions", failedRules };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    logger.error("Authorization check failed:", errorMessage);
+    logger.error("Authorization check failed:", { error: errorMessage });
     
     // Log the error for debugging
     if (user?.sub) {

--- a/src/features/users/hooks.ts
+++ b/src/features/users/hooks.ts
@@ -58,17 +58,25 @@ export const buildUsersListQuery = (params?: { search?: string }, enabled: boole
       const url = `${baseUrl}/api/users${
         params?.search ? `?search=${encodeURIComponent(params.search)}` : ""
       }`;
-      logger.info('🌐 [QUERY] API URL:', url, '(context:', typeof window !== 'undefined' ? 'client' : 'server', ')');
+      logger.info('🌐 [QUERY] API URL:', {
+        url,
+        context: typeof window !== 'undefined' ? 'client' : 'server',
+      });
       
       // Fetch API response with new format
       const response = await api<ApiResponse<User[]>>(url, { signal });
       
       // Extract users array from API response for backward compatibility
       if (response.success && response.data) {
-        logger.info('✅ [QUERY] API response successful, extracted', response.data.length, 'users');
+        logger.info('✅ [QUERY] API response successful, extracted users', {
+          count: response.data.length,
+        });
         return response.data; // Return just the users array
       } else {
-        logger.error('❌ [QUERY] API response failed:', response);
+        logger.error('❌ [QUERY] API response failed:', {
+          success: response.success,
+          message: response.message,
+        });
         throw new Error(response.message || 'Failed to fetch users');
       }
     },

--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -72,7 +72,7 @@ export function useTokenRefresh(options: UseTokenRefreshOptions = {}) {
         throw new Error('Token refresh returned null');
       }
     } catch (error) {
-      logger.error('❌ Token refresh failed:', error);
+      logger.error('❌ Token refresh failed:', undefined, error as Error);
       onRefreshError?.(error as Error);
       
       // If refresh fails, logout the user

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -39,7 +39,7 @@ export async function createAuditLog(data: AuditLogData) {
       },
     });
   } catch (error) {
-    logger.error('Failed to create audit log', undefined, error);
+    logger.error('Failed to create audit log', undefined, error as Error);
     // Don't throw - audit logging should not break main functionality
     return null;
   }
@@ -173,7 +173,7 @@ export async function getAuditLogs(
       take: limit,
     });
   } catch (error) {
-    logger.error('Failed to get audit logs', undefined, error);
+    logger.error('Failed to get audit logs', undefined, error as Error);
     return [];
   }
 }
@@ -198,7 +198,7 @@ export async function getUserAuditLogs(
       take: limit,
     });
   } catch (error) {
-    logger.error('Failed to get user audit logs', undefined, error);
+    logger.error('Failed to get user audit logs', undefined, error as Error);
     return [];
   }
 }
@@ -225,7 +225,7 @@ export async function cleanupAuditLogs(
 
     return result.count;
   } catch (error) {
-    logger.error('Failed to cleanup audit logs', undefined, error);
+    logger.error('Failed to cleanup audit logs', undefined, error as Error);
     return 0;
   }
 }

--- a/src/lib/csrf.ts
+++ b/src/lib/csrf.ts
@@ -9,6 +9,9 @@ const CSRF_SECRET = process.env.CSRF_SECRET;
 if (!CSRF_SECRET) {
   throw new Error('CSRF_SECRET environment variable is required');
 }
+
+const CSRF_SECRET_VALUE: string = CSRF_SECRET;
+
 const CSRF_TOKEN_HEADER = 'x-csrf-token';
 const CSRF_TOKEN_COOKIE = 'csrf-token';
 
@@ -24,7 +27,7 @@ export function generateCSRFToken(): string {
  */
 export function createCSRFHash(token: string): string {
   return crypto
-    .createHmac('sha256', CSRF_SECRET)
+    .createHmac('sha256', CSRF_SECRET_VALUE)
     .update(token)
     .digest('hex');
 }

--- a/src/lib/learning-analytics.ts
+++ b/src/lib/learning-analytics.ts
@@ -55,7 +55,7 @@ export async function startLearningSession(data: StartLearningSessionData) {
       },
     });
   } catch (error) {
-    logger.error('Failed to start learning session', undefined, error);
+    logger.error('Failed to start learning session', undefined, error as Error);
     throw error;
   }
 }
@@ -77,7 +77,7 @@ export async function updateLearningSession(
       },
     });
   } catch (error) {
-    logger.error('Failed to update learning session', undefined, error);
+    logger.error('Failed to update learning session', undefined, error as Error);
     throw error;
   }
 }
@@ -110,7 +110,7 @@ export async function endLearningSession(
       interactionCount,
     });
   } catch (error) {
-    logger.error('Failed to end learning session', undefined, error);
+    logger.error('Failed to end learning session', undefined, error as Error);
     throw error;
   }
 }
@@ -151,7 +151,7 @@ export async function getUserLearningSessions(
       skip: offset,
     });
   } catch (error) {
-    logger.error('Failed to get user learning sessions', undefined, error);
+    logger.error('Failed to get user learning sessions', undefined, error as Error);
     return [];
   }
 }
@@ -203,7 +203,7 @@ export async function getUserLearningAnalytics(userId: string, tenantId: string)
       recentSessions,
     };
   } catch (error) {
-    logger.error('Failed to get user learning analytics', undefined, error);
+    logger.error('Failed to get user learning analytics', undefined, error as Error);
     return {
       totalSessions: 0,
       completedSessions: 0,
@@ -250,7 +250,7 @@ export async function getCourseLearningAnalytics(courseId: string, tenantId: str
       completionRate: totalSessions > 0 ? (completedSessions / totalSessions) * 100 : 0,
     };
   } catch (error) {
-    logger.error('Failed to get course learning analytics', undefined, error);
+    logger.error('Failed to get course learning analytics', undefined, error as Error);
     return {
       totalSessions: 0,
       uniqueUsers: 0,
@@ -330,7 +330,7 @@ export async function getTenantLearningAnalytics(tenantId: string) {
       })),
     };
   } catch (error) {
-    logger.error('Failed to get tenant learning analytics', undefined, error);
+    logger.error('Failed to get tenant learning analytics', undefined, error as Error);
     return {
       totalSessions: 0,
       activeUsers: 0,
@@ -421,7 +421,7 @@ export async function getUserLearningStreak(userId: string, tenantId: string) {
       lastActivity: sessions[0].startedAt,
     };
   } catch (error) {
-    logger.error('Failed to get user learning streak', undefined, error);
+    logger.error('Failed to get user learning streak', undefined, error as Error);
     return { currentStreak: 0, longestStreak: 0, lastActivity: null };
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -17,7 +17,7 @@ export interface LogContext {
   tenantId?: string;
   requestId?: string;
   timestamp?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface LogEntry {

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -41,7 +41,7 @@ export async function createNotification(data: CreateNotificationData) {
       },
     });
   } catch (error) {
-    logger.error('Failed to create notification', undefined, error);
+    logger.error('Failed to create notification', undefined, error as Error);
     throw error;
   }
 }
@@ -158,7 +158,7 @@ export async function getUnreadNotifications(userId: string, tenantId: string) {
       take: 50,
     });
   } catch (error) {
-    logger.error('Failed to get unread notifications', undefined, error);
+    logger.error('Failed to get unread notifications', undefined, error as Error);
     return [];
   }
 }
@@ -203,7 +203,7 @@ export async function getUserNotifications(
       totalPages: Math.ceil(total / limit),
     };
   } catch (error) {
-    logger.error('Failed to get user notifications', undefined, error);
+    logger.error('Failed to get user notifications', undefined, error as Error);
     return {
       notifications: [],
       total: 0,
@@ -234,7 +234,7 @@ export async function markNotificationAsRead(
       },
     });
   } catch (error) {
-    logger.error('Failed to mark notification as read', undefined, error);
+    logger.error('Failed to mark notification as read', undefined, error as Error);
     throw error;
   }
 }
@@ -255,7 +255,7 @@ export async function markAllNotificationsAsRead(userId: string, tenantId: strin
       },
     });
   } catch (error) {
-    logger.error('Failed to mark all notifications as read', undefined, error);
+    logger.error('Failed to mark all notifications as read', undefined, error as Error);
     throw error;
   }
 }
@@ -283,7 +283,7 @@ export async function deleteOldNotifications(
 
     return result.count;
   } catch (error) {
-    logger.error('Failed to delete old notifications', undefined, error);
+    logger.error('Failed to delete old notifications', undefined, error as Error);
     return 0;
   }
 }
@@ -319,7 +319,7 @@ export async function getNotificationStats(userId: string, tenantId: string) {
       }, {} as Record<string, number>),
     };
   } catch (error) {
-    logger.error('Failed to get notification stats', undefined, error);
+    logger.error('Failed to get notification stats', undefined, error as Error);
     return {
       total: 0,
       unread: 0,


### PR DESCRIPTION
## Summary
- require logger context values to be `unknown` instead of `any`
- ensure errors are passed separately from serializable context objects
- adjust various logger call sites to supply structured context

## Testing
- `npx tsc --noEmit` *(fails: Argument of type 'RuleConditions | undefined' is not assignable to parameter of type 'string | string[] | undefined', etc.)*
- `npm test` *(fails: useAbility must be used within an AbilityProvider, window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fe0aa8590832981e0321319725822