### PR TITLE
fix: persist user in progress routes for logging

### DIFF
--- a/src/app/api/learning/progress/update/route.ts
+++ b/src/app/api/learning/progress/update/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
 import { z } from "zod";
+import type { User } from "@/types/api";
 
 // Validation schemas
 const progressUpdateSchema = z.object({
@@ -27,9 +28,10 @@ const learningSessionSchema = z.object({
 
 // POST /api/learning/progress/update - Update user learning progress
 export async function POST(request: NextRequest) {
+  let user: User | null = null;
   try {
     // Get user from request
-    const user = await getUserFromRequest(request);
+    user = await getUserFromRequest(request);
 
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/src/app/api/learning/progress/user/route.ts
+++ b/src/app/api/learning/progress/user/route.ts
@@ -3,12 +3,14 @@ import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
+import type { User } from "@/types/api";
 
 // GET /api/learning/progress/user - Get comprehensive user learning progress
 export async function GET(request: NextRequest) {
+  let user: User | null = null;
   try {
     // Get user from request
-    const user = await getUserFromRequest(request);
+    user = await getUserFromRequest(request);
 
     if (!user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });


### PR DESCRIPTION
## Summary
- keep a `user` reference outside try/catch in progress update route
- do the same for comprehensive progress route

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*

------
https://chatgpt.com/codex/tasks/task_e_689fe44e22f08329a4dacddbf69eafcc