### PR TITLE
chore: type casl decorator target

### DIFF
--- a/src/core/auth/casl.decorator.ts
+++ b/src/core/auth/casl.decorator.ts
@@ -6,8 +6,18 @@ export interface CheckAbilitiesOptions {
   rules: RequiredRule[];
 }
 
+interface CaslDecoratorTarget {
+  constructor: {
+    caslRules?: Record<string, RequiredRule[]>;
+  };
+}
+
 export const CheckAbilities = (...rules: RequiredRule[]) => {
-  return (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+  return (
+    target: CaslDecoratorTarget,
+    propertyKey: string,
+    descriptor: PropertyDescriptor,
+  ) => {
     // For Next.js API routes, we'll store the metadata differently
     // This is a simplified approach for demonstration
     if (!target.constructor.caslRules) {


### PR DESCRIPTION
## Summary
- type Casl decorator target with optional caslRules map
- update CheckAbilities decorator to accept typed target

## Testing
- `npm test` (fails: useAbility must be used within an AbilityProvider)
- `npm run lint` (fails: require() style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689fe791c73c8329a27c45151c38e870