### PR TITLE
refactor: improve ability server rule typing

### DIFF
--- a/src/core/auth/ability.ts
+++ b/src/core/auth/ability.ts
@@ -1,4 +1,4 @@
-import { AbilityBuilder } from '@casl/ability';
+import { AbilityBuilder, RawRuleOf } from '@casl/ability';
 import { createPrismaAbility, PrismaAbility, PrismaQuery } from '@casl/prisma';
 
 // Define the types for our application
@@ -342,21 +342,15 @@ export interface AbilityContext {
 }
 
 // Define proper server rules interface
-export interface ServerRule {
-  action: string;
-  subject: string;
-  conditions?: PrismaQuery;
-  inverted?: boolean;
-  reason?: string;
-}
+export type ServerRule = RawRuleOf<AppAbility>;
 
 export function buildAbility(
-  rulesFromServer: ServerRule[] | undefined,
+  rulesFromServer: RawRuleOf<AppAbility>[] | undefined,
   ctx: AbilityContext | undefined
 ): AppAbility {
   // If rulesFromServer is provided, use them directly
   if (rulesFromServer) {
-    return createPrismaAbility(rulesFromServer as any);
+    return createPrismaAbility(rulesFromServer);
   }
 
   // Check cache first


### PR DESCRIPTION
## Summary
- use CASL `RawRuleOf<AppAbility>` for `ServerRule`
- remove unsafe `as any` when building ability
- type `buildAbility` `rulesFromServer` parameter as `RawRuleOf<AppAbility>[]`

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*
- `npm run lint` *(errors: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe7935e188329b3d3b281c3ec0a40