### PR TITLE
refactor: add strong types for audio progress bookmarks

### DIFF
--- a/src/app/learning/hooks/useAudioProgress.ts
+++ b/src/app/learning/hooks/useAudioProgress.ts
@@ -45,11 +45,11 @@ export function useAudioProgress({
         // First try to load from localStorage for immediate display
         const stored = localStorage.getItem(`audio-progress-${storyId}`);
         if (stored) {
-          const parsedProgress = JSON.parse(stored);
+          const parsedProgress: AudioProgress = JSON.parse(stored);
           setProgress({
             ...parsedProgress,
             lastUpdated: new Date(parsedProgress.lastUpdated),
-            bookmarks: parsedProgress.bookmarks.map((bookmark: any) => ({
+            bookmarks: parsedProgress.bookmarks.map((bookmark: AudioBookmark) => ({
               ...bookmark,
               timestamp: new Date(bookmark.timestamp),
             })),
@@ -62,7 +62,7 @@ export function useAudioProgress({
             `/api/learning/progress/audio?storyId=${storyId}`
           );
           if (response.ok) {
-            const serverProgress = await response.json();
+            const serverProgress: AudioProgress = await response.json();
 
             // Use server data if it's more recent
             const localTimestamp = stored
@@ -75,7 +75,7 @@ export function useAudioProgress({
                 storyId,
                 currentPosition: serverProgress.currentPosition,
                 lastUpdated: serverTimestamp,
-                bookmarks: serverProgress.bookmarks.map((bookmark: any) => ({
+                bookmarks: serverProgress.bookmarks.map((bookmark: AudioBookmark) => ({
                   ...bookmark,
                   timestamp: new Date(bookmark.timestamp),
                 })),


### PR DESCRIPTION
## Summary
- use `AudioProgress` when parsing stored and server audio progress
- type audio bookmarks as `AudioBookmark` when normalizing timestamps

## Testing
- `npm test` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe795382883298f9191e12057517b