### PR TITLE
refactor: tighten lesson status type in admin lesson list

### DIFF
--- a/src/app/admin/lessons/AdminLessonList.tsx
+++ b/src/app/admin/lessons/AdminLessonList.tsx
@@ -9,6 +9,8 @@ import {
 import { getStatusClasses, LESSON_STATUS_COLORS } from "@/config/ui/status-colors";
 import { buildLessonsListQuery, type Lesson } from "@/features/lessons/hooks";
 
+type LessonStatus = keyof typeof LESSON_STATUS_COLORS;
+
 export default function AdminLessonList() {
   const { search, status } = useLessonsFilters();
   const { setSearch, setStatus, reset } = useLessonsFilterActions();
@@ -106,7 +108,10 @@ export default function AdminLessonList() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
-                      className={getStatusClasses(LESSON_STATUS_COLORS, lesson.status as any)}
+                      className={getStatusClasses(
+                        LESSON_STATUS_COLORS,
+                        lesson.status as LessonStatus
+                      )}
                     >
                       {lesson.status}
                     </span>


### PR DESCRIPTION
## Summary
- define `LessonStatus` from lesson status colors
- cast lesson status to `LessonStatus` in `AdminLessonList`

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, TypeError: window.matchMedia is not a function, etc.)*
- `npm run lint` *(fails: A `require()` style import is forbidden, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fe7975cb48329bd8698cd058c2a76