### PR TITLE
chore(auth): use logger for authorization check

### DIFF
--- a/src/core/auth/auth.logger.ts
+++ b/src/core/auth/auth.logger.ts
@@ -45,7 +45,7 @@ export class AuthLogger {
     allowed: boolean,
     metadata?: Record<string, unknown>
   ) {
-    console.info(`[AUTH] Authorization check:`, {
+    logger.info(`[AUTH] Authorization check:`, {
       userId,
       tenantId,
       action,


### PR DESCRIPTION
## Summary
- replace `console.info` with `logger.info` for authorization checks
- ensure all AuthLogger methods rely on shared logger

## Testing
- `npm test` (fails: 8 failed, 5 passed)
- `npm run lint` (fails with lint errors)


------
https://chatgpt.com/codex/tasks/task_e_689fe887a3448329a2ec05bfe84b8f25