### PR TITLE
refactor: remove unused imports

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,8 @@
-import { logger } from '@/lib/logger';
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { verifyJwt } from "@/core/auth/jwt";
 import type { JWTPayload } from "@/types/api";
-import jwt from "jsonwebtoken";
 import logger from "@/lib/logger";
-
-interface JwtPayload {
-  userId: string;
-  role: string;
-  email: string;
-  tenantId?: string;
-}
 
 // Security headers
 const securityHeaders = {


### PR DESCRIPTION
## Summary
- remove unused jwt import from middleware
- remove named logger import and keep default import

## Testing
- `npx eslint middleware.ts && echo 'Lint completed'`

------
https://chatgpt.com/codex/tasks/task_e_689fe887b4948329801d968ca615a31d