### PR TITLE
feat: improve prisma client typing

### DIFF
--- a/src/core/prisma.ts
+++ b/src/core/prisma.ts
@@ -1,6 +1,10 @@
 import { PrismaClient } from "@prisma/client";
 
-const globalForPrisma = globalThis as unknown as {
+declare global {
+    var prisma: PrismaClient | undefined;
+}
+
+const globalForPrisma = globalThis as {
     prisma?: PrismaClient;
 };
 


### PR DESCRIPTION
## Summary
- expose global Prisma client type to avoid unknown casts
- drop unnecessary `unknown` cast when accessing global Prisma instance

## Testing
- `npm test` *(fails: 8 failed, 5 passed)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fe889254883299c1d58cbfa68d040