### PR TITLE
chore(testing): type-safe global fetch mocking

### DIFF
--- a/src/core/api/testing.ts
+++ b/src/core/api/testing.ts
@@ -5,6 +5,10 @@ import React, { ReactNode } from 'react';
 import { apiClient } from './api';
 
 // Mock API responses - using unknown instead of any for better type safety
+interface GlobalWithFetch {
+  fetch: typeof fetch;
+}
+
 export interface MockResponse<T = unknown> {
   data?: T;
   error?: Error;
@@ -178,17 +182,17 @@ export const integrationTestHelpers = {
   setupTestEnvironment: () => {
     const mockClient = new MockApiClient();
     const queryClient = createTestQueryClient();
-    
+
     // Replace global fetch with mock
-    const originalFetch = global.fetch;
-    // Cast to satisfy TS overloads in different environments
-    (globalThis as any).fetch = mockClient.mockFetch.bind(mockClient) as any;
-    
+    const originalFetch = (globalThis as GlobalWithFetch).fetch;
+    (globalThis as GlobalWithFetch).fetch =
+      mockClient.mockFetch.bind(mockClient) as typeof fetch;
+
     return {
       mockClient,
       queryClient,
       cleanup: () => {
-        (globalThis as any).fetch = originalFetch as any;
+        (globalThis as GlobalWithFetch).fetch = originalFetch;
         queryClient.clear();
         mockClient.clearMocks();
       },


### PR DESCRIPTION
## Summary
- add `GlobalWithFetch` interface for global fetch mock typing
- replace any casts when mocking/restoring fetch in test helpers

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_689fe88a74248329bededd756317164a