### PR TITLE
refactor: tighten API types

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -153,13 +153,13 @@ export interface UserUpdateRequest extends Partial<Omit<UserCreateRequest, 'pass
 }
 
 // Query Client Types
-export interface QueryClientData<T = any> {
+export interface QueryClientData<T> {
   pages?: T[];
-  pageParams?: any[];
+  pageParams?: unknown[];
   data?: T;
 }
 
-export interface OptimisticUpdateContext<T = any> {
+export interface OptimisticUpdateContext<T> {
   previousData?: T;
   newData: T;
   queryKey: string[];
@@ -227,7 +227,7 @@ export interface PerformanceMetric {
   value: number;
   unit: 'ms' | 'bytes' | 'count';
   timestamp: string;
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 
 export interface QueryMetrics {


### PR DESCRIPTION
## Summary
- enforce generic typing in QueryClientData and OptimisticUpdateContext
- use unknown for pageParams and monitoring context
- audit repository for references to updated interfaces

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider; not implemented HTMLMediaElement.load; window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689fec646a188329b98ae3b0eb44a2a2