### PR TITLE
feat: type resource factory select generics

### DIFF
--- a/src/core/api/resourceFactory.ts
+++ b/src/core/api/resourceFactory.ts
@@ -1,4 +1,4 @@
-import { queryOptions, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { queryOptions, useQuery, useMutation, useQueryClient, type SelectFn } from "@tanstack/react-query";
 import { api } from "./api";
 import { queryProfiles, QueryProfileName } from "./queryConfig";
 import { keyFactory } from "./keyFactory";
@@ -13,35 +13,35 @@ function buildUrl(baseUrl: string, params?: ListParams) {
   return `${baseUrl}?${qs.toString()}`;
 }
 
-export function makeResource<N extends EntityName>(name: N) {
+export function makeResource<N extends EntityName, TSelectList = unknown, TSelectDetail = unknown>(name: N) {
   const def = entities[name];
 
-  function useList<T = unknown>(params?: ListParams, profile: QueryProfileName = "list") {
+  function useList<T = TSelectList>(params?: ListParams, profile: QueryProfileName = "list") {
     const prof = queryProfiles[profile];
     const url = buildUrl(def.baseUrl, params);
 
-    const hasSelectList = ("selectList" in def) && typeof (def as any).selectList === "function";
+    const hasSelectList = "selectList" in def && typeof def.selectList === "function";
     const opts = queryOptions({
       queryKey: keyFactory.list(def.entity, params),
       queryFn: () => api<T>(url),
       ...prof,
       placeholderData: (prev) => prev,
-      ...(hasSelectList ? { select: (def as any).selectList as any } : {}),
+      ...(hasSelectList ? { select: def.selectList as SelectFn<T> } : {}),
     });
     return useQuery(opts);
   }
 
-  function useDetail<T = unknown>(id: string | number, profile: QueryProfileName = "detail") {
+  function useDetail<T = TSelectDetail>(id: string | number, profile: QueryProfileName = "detail") {
     const prof = queryProfiles[profile];
     const url = `${def.baseUrl}/${id}`;
 
-    const hasSelectDetail = ("selectDetail" in def) && typeof (def as any).selectDetail === "function";
+    const hasSelectDetail = "selectDetail" in def && typeof def.selectDetail === "function";
     const opts = queryOptions({
       queryKey: keyFactory.detail(def.entity, id),
       queryFn: () => api<T>(url),
       enabled: !!id,
       ...prof,
-      ...(hasSelectDetail ? { select: (def as any).selectDetail as any } : {}),
+      ...(hasSelectDetail ? { select: def.selectDetail as SelectFn<T> } : {}),
     });
     return useQuery(opts);
   }


### PR DESCRIPTION
## Summary
- type `makeResource` with `TSelectList` and `TSelectDetail`
- use type-guard checks for entity select helpers
- avoid `any` cast by using `SelectFn`

## Testing
- `npm test` *(fails: "useAbility must be used within an AbilityProvider" and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_689fec681cc88329ba9b964bc8045416