### PR TITLE
refactor: use imported JWTPayload in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,8 @@
-import { logger } from '@/lib/logger';
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { verifyJwt } from "@/core/auth/jwt";
 import type { JWTPayload } from "@/types/api";
-import jwt from "jsonwebtoken";
 import logger from "@/lib/logger";
-
-interface JwtPayload {
-  userId: string;
-  role: string;
-  email: string;
-  tenantId?: string;
-}
 
 // Security headers
 const securityHeaders = {


### PR DESCRIPTION
## Summary
- remove custom `JwtPayload` interface and unused imports
- verify JWTs using the shared `JWTPayload` type

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689fec6b83648329a794d5f149c75edf