### PR TITLE
chore: type resource policy access

### DIFF
--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
 
 // getUserFromRequest imported from core auth
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 export async function PUT(_request: NextRequest, context: { params: { id: string } }) {
   const user = await getUserFromRequest(_request);
@@ -17,7 +20,7 @@ export async function PUT(_request: NextRequest, context: { params: { id: string
   if (!id) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
   const body = await _request.json();
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const updated = await repo.update({
@@ -39,7 +42,7 @@ export async function DELETE(_request: NextRequest, context: { params: { id: str
   const id = Number(context.params.id);
   if (!Number.isFinite(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   await repo.delete({ where: { id } });

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
 
 // getUserFromRequest imported from core auth
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 export async function GET(request: NextRequest) {
   const user = await getUserFromRequest(request);
@@ -18,7 +21,7 @@ export async function GET(request: NextRequest) {
   const tenantId = searchParams.get("tenantId") || undefined;
 
   // optional repo access to compile even if model not generated yet
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ data: [], success: true, meta: { total: 0 } });
 
   const where: any = {};
@@ -49,7 +52,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "name, resource and effect are required" }, { status: 400 });
   }
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const created = await repo.create({

--- a/src/core/auth/casl.guard.ts
+++ b/src/core/auth/casl.guard.ts
@@ -3,6 +3,7 @@ import { buildAbility } from "./ability";
 import { AuthLogger } from "./auth.logger";
 import { subject as caslSubject } from "@casl/ability";
 import { PrismaQuery } from "@casl/prisma";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { prisma } from "../prisma";
 
 export interface RequiredRule {
@@ -13,6 +14,8 @@ export interface RequiredRule {
 }
 
 type UserCtx = { sub: string; tenantId?: string; roles: string[] };
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 export function checkAbilities(
   rules: RequiredRule[],
@@ -117,7 +120,7 @@ export async function caslGuardWithPolicies(
 
     const subjects = Array.from(new Set(rules.map((r) => r.subject)));
     for (const subject of subjects) {
-      const repo = (prisma as unknown as { resourcePolicy?: { findMany: (args: unknown) => Promise<Array<{ effect: string; conditions: unknown }>> } }).resourcePolicy;
+      const repo = (prisma as PrismaWithPolicy).resourcePolicy;
       if (!repo) {
         // Client not generated for ResourcePolicy yet; skip ABAC and allow RBAC result
         break;


### PR DESCRIPTION
## Summary
- import Prisma and define PrismaWithPolicy helper type
- use typed ResourcePolicy delegate in policy APIs and guard

## Testing
- `npm test` *(fails: HTMLMediaElement.prototype.load not implemented, matchMedia not implemented, authorization tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689fedefdb208329a1d1c2a8b7ec33ad