### PR TITLE
refactor: use enums for test story

### DIFF
--- a/src/app/learning/test-story-reader.tsx
+++ b/src/app/learning/test-story-reader.tsx
@@ -3,14 +3,15 @@
 import React from "react";
 import { StoryReaderContainer } from "./components/StoryReaderContainer";
 import type { LearningStory } from "./types/learning";
+import { StoryType, DifficultyLevel, ChunkType } from "@prisma/client";
 
 // Test story data
 const testStory: LearningStory = {
   id: "test-story-1",
   title: "Test Story with Embedded Words",
   content: "This is a test story content.",
-  storyType: "chem" as any,
-  difficulty: "beginner" as any,
+  storyType: StoryType.chemdanhtu,
+  difficulty: DifficultyLevel.beginner,
   estimatedMinutes: 5,
   wordCount: 50,
   chemRatio: 0.2,
@@ -19,19 +20,19 @@ const testStory: LearningStory = {
       id: "chunk-1",
       chunkOrder: 1,
       chunkText: "Xin chào, tôi là một student đang học English.",
-      type: "chem" as any,
+      type: ChunkType.chem,
     },
     {
       id: "chunk-2",
       chunkOrder: 2,
       chunkText: "Hôm nay tôi sẽ đi đến library để đọc sách.",
-      type: "chem" as any,
+      type: ChunkType.chem,
     },
     {
       id: "chunk-3",
       chunkOrder: 3,
       chunkText: "Đây là một câu bình thường không có từ tiếng Anh.",
-      type: "normal" as any,
+      type: ChunkType.normal,
     },
   ],
 };


### PR DESCRIPTION
## Summary
- use Prisma StoryType, DifficultyLevel and ChunkType in test story reader

## Testing
- `npm test` *(fails: window.matchMedia is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fedf16b68832983950720bd99193f