### PR TITLE
refactor: tighten state and form types

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -199,7 +199,7 @@ export interface FormField {
     minLength?: number;
     maxLength?: number;
     pattern?: RegExp;
-    custom?: (value: any) => boolean | string;
+    custom?: (value: unknown) => boolean | string;
   };
 }
 
@@ -209,11 +209,11 @@ export interface FormData {
 
 // State Management Types
 export interface StoreState {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface StoreActions {
-  [key: string]: (...args: any[]) => void;
+  [key: string]: (...args: unknown[]) => void;
 }
 
 export interface StoreSlice<T extends StoreState, A extends StoreActions> {


### PR DESCRIPTION
## Summary
- use `unknown` in form field custom validator
- tighten store state and action signatures to `unknown`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Argument of type 'unknown' is not assignable to parameter of type 'Error | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_689fedf5496083298159d670dbe3bc94