### PR TITLE
chore: type exercise result handling

### DIFF
--- a/src/app/learning/components/LearningApp.tsx
+++ b/src/app/learning/components/LearningApp.tsx
@@ -55,12 +55,13 @@ import type {
   LearningStory,
   Exercise,
   VocabularyData,
+  ExerciseResult,
 } from "../types/learning";
 
 interface LearningAppProps {
   story: LearningStory;
   onStoryComplete?: (storyId: string) => void;
-  onExerciseComplete?: (results: any[]) => void;
+  onExerciseComplete?: (results: ExerciseResult[]) => void;
   className?: string;
 }
 
@@ -167,7 +168,7 @@ export const LearningApp = React.memo(function LearningApp({
     onStoryComplete?.(story.id);
   };
 
-  const handleExerciseComplete = (results: unknown[]) => {
+  const handleExerciseComplete = (results: ExerciseResult[]) => {
     onExerciseComplete?.(results);
     setActivePanel("progress");
   };


### PR DESCRIPTION
## Summary
- import ExerciseResult for learning components
- type exercise completion handler and prop with ExerciseResult[]

## Testing
- `npm test` *(fails: HTMLMediaElement.prototype.load not implemented, etc.)*
- `npm run lint` *(errors: `require()` style import is forbidden, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689fedf6b38c8329a9dbb8c152822795