### PR TITLE
feat: save user preferences via API

### DIFF
--- a/src/app/api/user/preferences/route.ts
+++ b/src/app/api/user/preferences/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/core/prisma";
+import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
+import { getUserFromRequest } from "@/core/auth/getUser";
+import type { RequiredRule } from "@/types/api";
+import logger from "@/lib/logger";
+
+// PUT /api/user/preferences - Update current user's preferences
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await getUserFromRequest(request);
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const rules: RequiredRule[] = [{ action: "update", subject: "User" }];
+    const { allowed, error } = await caslGuardWithPolicies(rules, user);
+    if (!allowed) {
+      return NextResponse.json(
+        { error: error || "Forbidden" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+
+    const updated = await prisma.user.update({
+      where: { id: user.sub },
+      data: { preferences: body },
+      select: { preferences: true },
+    });
+
+    return NextResponse.json(updated.preferences);
+  } catch (err) {
+    logger.error("Error updating user preferences", undefined, err);
+    return NextResponse.json(
+      { error: "Failed to update preferences" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/learning/components/SettingsPanel.tsx
+++ b/src/app/learning/components/SettingsPanel.tsx
@@ -101,6 +101,7 @@ export function SettingsPanel({
   onPreferencesChange,
   onClose,
   className = "",
+  isSaving = false,
 }: SettingsPanelProps) {
   const [localPreferences, setLocalPreferences] =
     useState<UserLearningPreferences>(preferences);
@@ -124,9 +125,13 @@ export function SettingsPanel({
     handlePreferenceChange("topicPreferences", newTopics);
   };
 
-  const handleSave = () => {
-    onPreferencesChange(localPreferences);
-    onClose();
+  const handleSave = async () => {
+    const success = await onPreferencesChange(localPreferences);
+    if (success) {
+      onClose();
+    } else {
+      alert("Không thể lưu cài đặt");
+    }
   };
 
   const handleReset = () => {
@@ -502,8 +507,9 @@ export function SettingsPanel({
             <Button
               onClick={handleSave}
               className="bg-blue-600 hover:bg-blue-700"
+              disabled={isSaving}
             >
-              Lưu cài đặt
+              {isSaving ? "Đang lưu..." : "Lưu cài đặt"}
             </Button>
           </div>
         </div>

--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -70,6 +70,7 @@ function LearningPageContent() {
   const {
     preferences,
     isLoading: preferencesLoading,
+    isSaving: preferencesSaving,
     savePreferences,
     getStoryFilters,
   } = useUserPreferences();
@@ -151,13 +152,23 @@ function LearningPageContent() {
   const handlePreferencesChange = async (
     newPreferences: typeof preferences
   ) => {
-    await savePreferences(newPreferences);
+    const success = await savePreferences(newPreferences);
+    if (!success) {
+      alert("Không thể lưu cài đặt");
+    }
+    return success;
   };
 
   const handleAcceptDifficultyChange = async (
     newLevel: typeof preferences.difficultyLevel
   ) => {
-    await savePreferences({ ...preferences, difficultyLevel: newLevel });
+    const success = await savePreferences({
+      ...preferences,
+      difficultyLevel: newLevel,
+    });
+    if (!success) {
+      alert("Không thể lưu cài đặt");
+    }
   };
 
   const handleStartVocabularyReview = () => {
@@ -570,6 +581,7 @@ function LearningPageContent() {
               preferences={preferences}
               onPreferencesChange={handlePreferencesChange}
               onClose={handleCloseSettings}
+              isSaving={preferencesSaving}
             />
           )}
 

--- a/src/app/learning/types/learning.ts
+++ b/src/app/learning/types/learning.ts
@@ -223,9 +223,12 @@ export type ReviewFrequency = "daily" | "every_other_day" | "weekly";
 
 export interface SettingsPanelProps {
   preferences: UserLearningPreferences;
-  onPreferencesChange: (preferences: UserLearningPreferences) => void;
+  onPreferencesChange: (
+    preferences: UserLearningPreferences
+  ) => Promise<boolean>;
   onClose: () => void;
   className?: string;
+  isSaving?: boolean;
 }
 
 export interface PreferenceSection {


### PR DESCRIPTION
## Summary
- add authenticated PUT /api/user/preferences endpoint
- persist settings through API in useUserPreferences hook
- await preference saves in UI and display saving state

## Testing
- `npm test` (fails: useAbility must be used within an AbilityProvider / window.matchMedia is not a function)


------
https://chatgpt.com/codex/tasks/task_e_689feff76bec8329b919c6ed7bf6766f