### PR TITLE
feat: add vocabulary review page and navigation

### DIFF
--- a/src/app/learning/page.tsx
+++ b/src/app/learning/page.tsx
@@ -2,6 +2,7 @@
 import { logger } from '@/lib/logger';
 
 import React, { useState } from "react";
+import { useRouter } from "next/navigation";
 import { Require } from "@/core/auth/Require";
 import { FadeIn } from "@/components/ui/fade-in";
 import {
@@ -52,6 +53,7 @@ export default function LearningPage() {
 }
 
 function LearningPageContent() {
+  const router = useRouter();
   const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
   const [selectedStory, setSelectedStory] = useState<LearningStory | null>(
     null
@@ -161,8 +163,8 @@ function LearningPageContent() {
   };
 
   const handleStartVocabularyReview = () => {
-    // TODO: Navigate to vocabulary review page
     logger.info("Starting vocabulary review...");
+    router.push("/learning/vocabulary");
   };
 
   const handleShowDownloadManager = () => {

--- a/src/app/learning/vocabulary/page.tsx
+++ b/src/app/learning/vocabulary/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import React from "react";
+import { Require } from "@/core/auth/Require";
+import { VocabularyProgressManager } from "../components/VocabularyProgressManager";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export default function VocabularyPage() {
+  const router = useRouter();
+
+  return (
+    <Require action="read" subject="Story">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50">
+        <div className="container mx-auto px-4 py-8 space-y-6">
+          <Button
+            variant="ghost"
+            onClick={() => router.push("/learning")}
+            className="flex items-center gap-2"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Quay lại trang học
+          </Button>
+
+          <h1 className="text-3xl font-bold text-gray-900">
+            Ôn tập từ vựng
+          </h1>
+          <VocabularyProgressManager userId="current-user" />
+        </div>
+      </div>
+    </Require>
+  );
+}
+


### PR DESCRIPTION
## Summary
- navigate to vocabulary review using Next.js router
- add vocabulary review page with progress manager and back button

## Testing
- `npm test` *(fails: HTMLMediaElement.prototype.load and other environment limitations)*
- `npm run lint` *(warnings: unexpected any, unescaped entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689feff8ba5883299feaf1e569f7bbaa