### PR TITLE
refactor progress tests for stricter typing

### DIFF
--- a/src/__tests__/api/progress.test.ts
+++ b/src/__tests__/api/progress.test.ts
@@ -25,7 +25,7 @@ jest.mock("@/core/auth/casl.guard", () => ({
   caslGuardWithPolicies: jest.fn(),
 }));
 
-const mockPrisma = prisma as any;
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetUser = getUserFromRequest as jest.MockedFunction<
   typeof getUserFromRequest
 >;

--- a/src/__tests__/features/progress/hooks.test.tsx
+++ b/src/__tests__/features/progress/hooks.test.tsx
@@ -11,6 +11,7 @@ import {
   useUpdateProgress,
   useDeleteProgress,
 } from "@/features/progress/hooks";
+import type { UserProgress as Progress } from "@/features/progress/hooks";
 import { api } from "@/core/api/api";
 
 // Mock API
@@ -67,7 +68,7 @@ describe("Progress Hooks", () => {
   });
 
   it("lists progress records", async () => {
-    const mockList = [] as any[];
+    const mockList: Progress[] = [];
     mockApi.mockResolvedValueOnce(mockList);
 
     const wrapper = createWrapper();


### PR DESCRIPTION
## Summary
- add Progress type usage in progress hooks test
- type prisma mock with jest.Mocked in API progress test

## Testing
- `npm test` *(fails: Error: Not implemented: HTMLMediaElement.prototype.load, others)*

------
https://chatgpt.com/codex/tasks/task_e_689ff1073b7c8329a9612116760960de