### PR TITLE
refactor: type resourcePolicy delegate

### DIFF
--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 // getUserFromRequest imported from core auth
 
@@ -17,7 +20,7 @@ export async function PUT(_request: NextRequest, context: { params: { id: string
   if (!id) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
   const body = await _request.json();
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const updated = await repo.update({
@@ -39,7 +42,7 @@ export async function DELETE(_request: NextRequest, context: { params: { id: str
   const id = Number(context.params.id);
   if (!Number.isFinite(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   await repo.delete({ where: { id } });

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
+import type { Prisma, PrismaClient } from "@prisma/client";
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 // getUserFromRequest imported from core auth
 
@@ -18,7 +21,7 @@ export async function GET(request: NextRequest) {
   const tenantId = searchParams.get("tenantId") || undefined;
 
   // optional repo access to compile even if model not generated yet
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ data: [], success: true, meta: { total: 0 } });
 
   const where: any = {};
@@ -49,7 +52,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "name, resource and effect are required" }, { status: 400 });
   }
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const created = await repo.create({


### PR DESCRIPTION
## Summary
- add PrismaWithPolicy type to access resourcePolicy delegate
- remove `any` casts in policy routes

## Testing
- `npm run lint`
- `npm test` *(fails: useAbility must be used within an AbilityProvider, AudioPlayer tests, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689ff109e09c8329a66aeba6debcf7a6