### PR TITLE
feat(api): handle non-JSON responses

### DIFF
--- a/src/__tests__/core/api/api.test.ts
+++ b/src/__tests__/core/api/api.test.ts
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment node
+ */
+
+import { apiClient } from "@/core/api/api";
+
+describe("ApiClient.request", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("returns parsed JSON for object type", async () => {
+    const data = { foo: "bar" };
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(JSON.stringify(data), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const result = await apiClient.request<typeof data>("/test");
+    expect(result).toEqual(data);
+  });
+
+  it("returns text for string type", async () => {
+    const text = "hello";
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response(text, {
+        status: 200,
+        headers: { "Content-Type": "text/plain" },
+      })
+    );
+
+    const result = await apiClient.request<string>("/test");
+    expect(result).toBe(text);
+  });
+});

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -213,7 +213,9 @@ class ApiClient {
     return url; // prefer relative path on client
   }
 
-  async request<T = unknown>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  async request(input: RequestInfo, init?: RequestInit): Promise<string>;
+  async request<T>(input: RequestInfo, init?: RequestInit): Promise<T>;
+  async request<T>(input: RequestInfo, init?: RequestInit): Promise<T | string> {
     try {
       let config: RequestInit & { url: string } = {
         ...init,
@@ -245,7 +247,9 @@ class ApiClient {
         throw new ApiError(message, response.status, body, `HTTP_${response.status}`);
       }
 
-      return (body as T) ?? (await response.text() as unknown as T);
+      if (isJson) return body as T;
+      const text = await response.text();
+      return text;
     } catch (err) {
       let e = err as Error;
       for (const i of this.errorInterceptors) {


### PR DESCRIPTION
## Summary
- split JSON and text handling in ApiClient.request
- add tests for string and object responses

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, etc.)*
- `npm test src/__tests__/core/api/api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689ff10f00a08329814a18d39f23bed1