### PR TITLE
refactor: make api errors type-safe

### DIFF
--- a/src/core/api/errorHandling.ts
+++ b/src/core/api/errorHandling.ts
@@ -1,9 +1,9 @@
 // Enhanced error handling with custom error types
-export class ApiError extends Error {
+export class ApiError<T = unknown> extends Error {
   constructor(
     message: string,
     public status: number,
-    public body?: any,
+    public body?: T,
     public code?: string
   ) {
     super(message);
@@ -18,11 +18,11 @@ export class NetworkError extends Error {
   }
 }
 
-export class ValidationError extends Error {
+export class ValidationError<T = unknown> extends Error {
   constructor(
     message: string,
     public field?: string,
-    public value?: any
+    public value?: T
   ) {
     super(message);
     this.name = 'ValidationError';


### PR DESCRIPTION
## Summary
- make `ApiError` and `ValidationError` generic to support typed payloads
- replace loose `any` fields with `unknown`

## Testing
- `npm test` *(fails: 50 failed, 58 passed)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a01ef970c4832991a0367930294fe8