### PR TITLE
refactor: tighten validation generics

### DIFF
--- a/src/config/api/validation.ts
+++ b/src/config/api/validation.ts
@@ -102,15 +102,22 @@ export const USER_VALIDATION_RULES: ValidationRules = {
 };
 
 // Validation Helper Functions
-export function validateField(value: any, rule: ValidationRule): string[] {
+export function validateField(value: unknown, rule: ValidationRule): string[] {
   const errors: string[] = [];
 
-  if (rule.required && (value === undefined || value === null || value === '')) {
+  if (
+    rule.required &&
+    (value === undefined || value === null || (typeof value === 'string' && value === ''))
+  ) {
     errors.push('This field is required');
     return errors;
   }
 
-  if (value === undefined || value === null || value === '') {
+  if (
+    value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value === '')
+  ) {
     return errors; // Skip other validations if not required and empty
   }
 
@@ -135,14 +142,17 @@ export function validateField(value: any, rule: ValidationRule): string[] {
     }
   }
 
-  if (rule.enum && !rule.enum.includes(value)) {
+  if (rule.enum && (typeof value !== 'string' || !rule.enum.includes(value))) {
     errors.push(`Must be one of: ${rule.enum.join(', ')}`);
   }
 
   return errors;
 }
 
-export function validateObject(obj: Record<string, any>, rules: ValidationRules): Record<string, string[]> {
+export function validateObject(
+  obj: Record<string, unknown>,
+  rules: ValidationRules
+): Record<string, string[]> {
   const errors: Record<string, string[]> = {};
 
   for (const [field, rule] of Object.entries(rules)) {


### PR DESCRIPTION
## Summary
- use `unknown` instead of `any` in validation helpers
- narrow `validateObject` input to `Record<string, unknown>`

## Testing
- `npm test` *(fails: Cannot read properties of undefined (reading '1'), window.matchMedia is not a function, expect(received).toBe(expected))*

------
https://chatgpt.com/codex/tasks/task_e_68a01ef91af883298391b6e5e8ca9056