### PR TITLE
feat: validate accessibility settings

### DIFF
--- a/src/app/learning/contexts/AccessibilityContext.tsx
+++ b/src/app/learning/contexts/AccessibilityContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { logger } from '@/lib/logger';
+import { z } from "zod";
 
 import React, {
   createContext,
@@ -10,13 +11,15 @@ import React, {
 } from "react";
 import { HighContrastManager, AriaLiveAnnouncer } from "../utils/accessibility";
 
-interface AccessibilitySettings {
-  highContrast: boolean;
-  reducedMotion: boolean;
-  fontSize: "small" | "medium" | "large" | "extra-large";
-  keyboardNavigation: boolean;
-  screenReaderOptimized: boolean;
-}
+const accessibilitySettingsSchema = z.object({
+  highContrast: z.boolean(),
+  reducedMotion: z.boolean(),
+  fontSize: z.enum(["small", "medium", "large", "extra-large"]),
+  keyboardNavigation: z.boolean(),
+  screenReaderOptimized: z.boolean(),
+});
+
+type AccessibilitySettings = z.infer<typeof accessibilitySettingsSchema>;
 
 interface AccessibilityContextType {
   settings: AccessibilitySettings;
@@ -78,9 +81,19 @@ export function AccessibilityProvider({
     if (savedSettings) {
       try {
         const parsed = JSON.parse(savedSettings);
-        setSettings((prev) => ({ ...prev, ...parsed }));
+        const result = accessibilitySettingsSchema.safeParse(parsed);
+        if (result.success) {
+          setSettings((prev) => ({ ...prev, ...result.data }));
+        } else {
+          logger.warn(
+            "Invalid saved accessibility settings, using defaults:",
+            result.error,
+          );
+          setSettings(defaultSettings);
+        }
       } catch (error) {
         logger.warn("Failed to parse saved accessibility settings:", error);
+        setSettings(defaultSettings);
       }
     }
 


### PR DESCRIPTION
## Summary
- add Zod schema for accessibility settings and validate saved values
- log warning and fall back to defaults when invalid settings are detected

## Testing
- `npm test` (fails: useAbility must be used within an AbilityProvider)
- `npm run lint` (warnings: A `require()` style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_689ff43b9d348329984239f1f51d4978