### PR TITLE
fix: use slice for session ID generation

### DIFF
--- a/src/app/learning/hooks/useOfflineProgress.ts
+++ b/src/app/learning/hooks/useOfflineProgress.ts
@@ -127,7 +127,7 @@ export function useOfflineProgress(userId: string) {
   // Start a new learning session
   const startLearningSession = useCallback((storyId: string) => {
     const session: LearningSession = {
-      id: `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      id: `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
       storyId,
       startTime: new Date(),
       timeSpent: 0,


### PR DESCRIPTION
## Summary
- replace deprecated `substr` with `slice` when generating offline session IDs

## Testing
- `node -e "for(let i=0;i<5;i++){const s=Math.random().toString(36).slice(2,11); console.log(s,s.length);}"`
- `npm test` *(fails: 8 failed, 5 passed)*


------
https://chatgpt.com/codex/tasks/task_e_689ff43695e483299dd91d66dbcfa0cc