### PR TITLE
feat(progress): validate local storage data

### DIFF
--- a/src/app/learning/hooks/useProgress.ts
+++ b/src/app/learning/hooks/useProgress.ts
@@ -2,6 +2,7 @@
 import { logger } from '@/lib/logger';
 
 import { useState, useEffect, useCallback } from "react";
+import { z } from "zod";
 import type {
   LearningProgress,
   VocabularyProgress,
@@ -9,6 +10,22 @@ import type {
   LearningStats,
   Achievement,
 } from "../types/learning";
+
+interface StoredProgressData {
+  progress: LearningProgress | null;
+  vocabularyProgress?: VocabularyProgress[];
+  levelProgress: LevelProgress | null;
+  stats: LearningStats | null;
+  lastUpdated?: string;
+}
+
+const storedProgressSchema: z.ZodType<StoredProgressData> = z.object({
+  progress: z.any().nullable(),
+  vocabularyProgress: z.array(z.any()).optional(),
+  levelProgress: z.any().nullable(),
+  stats: z.any().nullable(),
+  lastUpdated: z.string().optional(),
+});
 
 interface UseProgressOptions {
   userId: string;
@@ -80,11 +97,16 @@ export function useProgress({
     try {
       const stored = localStorage.getItem(`learning-progress-${userId}`);
       if (stored) {
-        const data = JSON.parse(stored);
-        setProgress(data.progress);
-        setVocabularyProgress(data.vocabularyProgress || []);
-        setLevelProgress(data.levelProgress);
-        setStats(data.stats);
+        const parsed = storedProgressSchema.safeParse(JSON.parse(stored));
+        if (parsed.success) {
+          const data = parsed.data;
+          setProgress(data.progress);
+          setVocabularyProgress(data.vocabularyProgress ?? []);
+          setLevelProgress(data.levelProgress);
+          setStats(data.stats);
+        } else {
+          logger.warn("Invalid progress data in localStorage");
+        }
       }
     } catch (err) {
       logger.error("Error loading from localStorage:", err);


### PR DESCRIPTION
## Summary
- define `StoredProgressData` and schema for progress caching
- safely parse localStorage progress with schema validation

## Testing
- `npm test` (fails: Not implemented: HTMLMediaElement.prototype.load)
- `npm run lint` (fails: A `require()` style import is forbidden)

------
https://chatgpt.com/codex/tasks/task_e_689ff434627c8329b1a3ce9bfaba86b0