### PR TITLE
feat: handle tenant id in learning session

### DIFF
--- a/src/app/api/learning/exercises/submit/route.ts
+++ b/src/app/api/learning/exercises/submit/route.ts
@@ -88,7 +88,8 @@ export async function POST(request: NextRequest) {
         await updateLearningSession(
           user.id,
           submission.storyId,
-          submission.timeSpent || 0
+          submission.timeSpent || 0,
+          user.tenantId
         );
 
         // Update vocabulary progress if applicable
@@ -258,8 +259,15 @@ async function validateDatabaseExercise(submission: ExerciseSubmission) {
 async function updateLearningSession(
   userId: string,
   storyId: string,
-  timeSpent: number
+  timeSpent: number,
+  tenantId?: string
 ) {
+  if (!tenantId) {
+    logger.warn(
+      "Tenant ID missing when updating learning session, defaulting to 'default'",
+      { userId, storyId }
+    );
+  }
   // Find or create learning session for today
   const today = new Date();
   today.setHours(0, 0, 0, 0);
@@ -294,7 +302,7 @@ async function updateLearningSession(
         endedAt: new Date(),
         timeSpentSec: timeSpent,
         interactionCount: 1,
-        tenantId: "default", // You might want to get this from the user context
+        tenantId: tenantId || "default",
       },
     });
   }


### PR DESCRIPTION
## Summary
- pass tenant id from user context when updating exercise sessions
- log and default tenant id when missing in learning session creation

## Testing
- `npm test` *(fails: 8 failed, 5 passed)*
- `npm run lint` *(warnings about unused variables and explicit any)*

------
https://chatgpt.com/codex/tasks/task_e_689ff364cdc88329b159d8e534c0ffc2