### PR TITLE
refactor auth token verification to use shared util

### DIFF
--- a/src/core/auth/getUser.ts
+++ b/src/core/auth/getUser.ts
@@ -37,18 +37,7 @@ export async function getUserFromRequest(
     }
     if (!token) return null;
 
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      if (process.env.NODE_ENV !== "production") {
-        logger.warn("getUserFromRequest: JWT_SECRET is not set; failing closed.");
-      }
-      return null;
-    }
-
-    const decoded = jwt.verify(token, secret, {
-      algorithms: ["HS256"],
-      ignoreExpiration: false,
-    }) as JWTPayload;
+    const decoded = verifyJwt<JWTPayload>(token);
 
     return {
       sub: decoded.userId,
@@ -57,7 +46,7 @@ export async function getUserFromRequest(
     };
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
-      logger.warn("getUserFromRequest: token verification failed:", err);
+      logger.warn("getUserFromRequest: token verification failed:", { error: err });
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- simplify `getUserFromRequest` by using `verifyJwt`
- log verification failures with structured context

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '...'; many TS errors not related to the change)*
- `npm test` *(fails: 7 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ff35ffe5c83299353f9170a58b244