### PR TITLE
refactor: tighten lesson status typing

### DIFF
--- a/src/app/admin/lessons/AdminLessonList.tsx
+++ b/src/app/admin/lessons/AdminLessonList.tsx
@@ -9,6 +9,8 @@ import {
 import { getStatusClasses, LESSON_STATUS_COLORS } from "@/config/ui/status-colors";
 import { buildLessonsListQuery, type Lesson } from "@/features/lessons/hooks";
 
+type LessonStatus = keyof typeof LESSON_STATUS_COLORS;
+
 export default function AdminLessonList() {
   const { search, status } = useLessonsFilters();
   const { setSearch, setStatus, reset } = useLessonsFilterActions();
@@ -106,7 +108,10 @@ export default function AdminLessonList() {
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
                     <span
-                      className={getStatusClasses(LESSON_STATUS_COLORS, lesson.status as any)}
+                      className={getStatusClasses(
+                        LESSON_STATUS_COLORS,
+                        lesson.status as LessonStatus
+                      )}
                     >
                       {lesson.status}
                     </span>


### PR DESCRIPTION
## Summary
- define LessonStatus as keys of LESSON_STATUS_COLORS
- use LessonStatus instead of `any` when styling lesson status

## Testing
- `npm test` *(fails: 8 failing suites, 50 failing tests)*
- `npm run lint` *(fails: ESLint warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f04e3ec83299c80278f42336143