### PR TITLE
Use logger for authorization check

### DIFF
--- a/src/core/auth/auth.logger.ts
+++ b/src/core/auth/auth.logger.ts
@@ -45,7 +45,7 @@ export class AuthLogger {
     allowed: boolean,
     metadata?: Record<string, unknown>
   ) {
-    console.info(`[AUTH] Authorization check:`, {
+    logger.info(`[AUTH] Authorization check:`, {
       userId,
       tenantId,
       action,


### PR DESCRIPTION
## Summary
- replace `console.info` with `logger.info` in `AuthLogger.logAuthorizationCheck` to ensure consistent logging

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider, window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f06fce08329944968e3025772d0