### PR TITLE
chore: remove unused imports from middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,8 @@
-import { logger } from '@/lib/logger';
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { verifyJwt } from "@/core/auth/jwt";
 import type { JWTPayload } from "@/types/api";
-import jwt from "jsonwebtoken";
 import logger from "@/lib/logger";
-
-interface JwtPayload {
-  userId: string;
-  role: string;
-  email: string;
-  tenantId?: string;
-}
 
 // Security headers
 const securityHeaders = {


### PR DESCRIPTION
## Summary
- remove unused logger and JWT imports from middleware
- drop unused JwtPayload interface

## Testing
- `npx eslint middleware.ts && echo 'Lint passed'`


------
https://chatgpt.com/codex/tasks/task_e_68a01f0765108329984b40fa59a77cfc