### PR TITLE
chore: improve fetch typing in test helpers

### DIFF
--- a/src/core/api/testing.ts
+++ b/src/core/api/testing.ts
@@ -4,6 +4,10 @@ import type { QueryKey } from '@tanstack/react-query';
 import React, { ReactNode } from 'react';
 import { apiClient } from './api';
 
+interface GlobalWithFetch {
+  fetch: typeof fetch;
+}
+
 // Mock API responses - using unknown instead of any for better type safety
 export interface MockResponse<T = unknown> {
   data?: T;
@@ -180,15 +184,15 @@ export const integrationTestHelpers = {
     const queryClient = createTestQueryClient();
     
     // Replace global fetch with mock
-    const originalFetch = global.fetch;
+    const originalFetch = (globalThis as GlobalWithFetch).fetch;
     // Cast to satisfy TS overloads in different environments
-    (globalThis as any).fetch = mockClient.mockFetch.bind(mockClient) as any;
+    (globalThis as GlobalWithFetch).fetch = mockClient.mockFetch.bind(mockClient) as typeof fetch;
     
     return {
       mockClient,
       queryClient,
       cleanup: () => {
-        (globalThis as any).fetch = originalFetch as any;
+        (globalThis as GlobalWithFetch).fetch = originalFetch;
         queryClient.clear();
         mockClient.clearMocks();
       },


### PR DESCRIPTION
## Summary
- type global fetch in integration test helpers
- restore original fetch with correct typings

## Testing
- `npm test` (fails: 8 failed, 5 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a01f0928288329bca9036d03bb5e12