### PR TITLE
refactor: improve api types generics

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -153,13 +153,13 @@ export interface UserUpdateRequest extends Partial<Omit<UserCreateRequest, 'pass
 }
 
 // Query Client Types
-export interface QueryClientData<T = any> {
+export interface QueryClientData<T> {
   pages?: T[];
-  pageParams?: any[];
+  pageParams?: unknown[];
   data?: T;
 }
 
-export interface OptimisticUpdateContext<T = any> {
+export interface OptimisticUpdateContext<T> {
   previousData?: T;
   newData: T;
   queryKey: string[];
@@ -227,7 +227,7 @@ export interface PerformanceMetric {
   value: number;
   unit: 'ms' | 'bytes' | 'count';
   timestamp: string;
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
 }
 
 export interface QueryMetrics {


### PR DESCRIPTION
## Summary
- use explicit generic type for QueryClientData and OptimisticUpdateContext
- restrict QueryClientData pageParams to unknown[]
- harden PerformanceMetric context typing

## Testing
- `npm test` (fails: useAbility must be used within an AbilityProvider, etc.)
- `npm run lint` (fails: no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68a01f0e021c8329bc6ee7248b9b060a