### PR TITLE
refactor: add type aliases for role and policy

### DIFF
--- a/src/app/admin/policies/AdminPoliciesList.tsx
+++ b/src/app/admin/policies/AdminPoliciesList.tsx
@@ -11,6 +11,8 @@ import {
   type UpsertPolicyInput,
 } from "@/features/policies/hooks";
 
+type PolicyEffect = "allow" | "deny";
+
 export default function AdminPoliciesList() {
   const [resourceFilter, setResourceFilter] = useState("");
   const [tenantFilter, setTenantFilter] = useState<string | null>(null);
@@ -173,7 +175,7 @@ function PolicyModal({
   const [form, setForm] = useState<UpsertPolicyInput>({
     resource: initial?.resource || "",
     action: initial?.action || null,
-    effect: (initial?.effect as "allow" | "deny") || "deny",
+    effect: (initial?.effect as PolicyEffect) || "deny",
     conditions: (initial?.conditions as Record<string, unknown>) || null,
     priority: initial?.priority ?? 100,
     tenantId: (initial?.tenantId as string | null) ?? null,
@@ -206,7 +208,7 @@ function PolicyModal({
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Effect *</label>
-                <select className="w-full px-3 py-2 border rounded-md" value={form.effect} onChange={(e) => setForm({ ...form, effect: e.target.value as any })}>
+                <select className="w-full px-3 py-2 border rounded-md" value={form.effect} onChange={(e) => setForm({ ...form, effect: e.target.value as PolicyEffect })}>
                   <option value="allow">allow</option>
                   <option value="deny">deny</option>
                 </select>

--- a/src/app/admin/users/AdminUserList.tsx
+++ b/src/app/admin/users/AdminUserList.tsx
@@ -12,10 +12,12 @@ import {
 import { useUsersFilters, useUsersFilterActions } from "@/features/users/state";
 import { useState } from "react";
 
+type UserRole = "student" | "coach" | "admin";
+
 interface UserFormData {
   name: string;
   email: string;
-  role: "student" | "coach" | "admin";
+  role: UserRole;
 }
 
 export default function AdminUserList() {
@@ -317,7 +319,7 @@ export default function AdminUserList() {
                 <select
                   value={formData.role}
                   onChange={(e) =>
-                    setFormData({ ...formData, role: e.target.value as any })
+                    setFormData({ ...formData, role: e.target.value as UserRole })
                   }
                   style={{
                     width: "100%",


### PR DESCRIPTION
## Summary
- define UserRole alias and ensure form role is strongly typed
- add PolicyEffect alias and cast policy effect selection

## Testing
- `npm test` (fails: Test Suites: 8 failed, 5 passed, 13 total)
- `npm run lint` (fails: A `require()` style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a01f1362cc8329af7930b707eb9d6b