### PR TITLE
refactor: use JWTPayload in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,17 +1,8 @@
-import { logger } from '@/lib/logger';
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { verifyJwt } from "@/core/auth/jwt";
 import type { JWTPayload } from "@/types/api";
-import jwt from "jsonwebtoken";
 import logger from "@/lib/logger";
-
-interface JwtPayload {
-  userId: string;
-  role: string;
-  email: string;
-  tenantId?: string;
-}
 
 // Security headers
 const securityHeaders = {


### PR DESCRIPTION
## Summary
- remove unused `JwtPayload` interface from middleware
- rely on imported `JWTPayload` when verifying token
- clean up logger imports

## Testing
- `npx eslint middleware.ts`
- `npm test` *(fails: 8 failed, 5 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68a01f1378688329a8211190f2bc61f2