### PR TITLE
refactor: use typed Prisma policy access

### DIFF
--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 // getUserFromRequest imported from core auth
 
@@ -17,7 +20,7 @@ export async function PUT(_request: NextRequest, context: { params: { id: string
   if (!id) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
   const body = await _request.json();
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const updated = await repo.update({
@@ -39,7 +42,7 @@ export async function DELETE(_request: NextRequest, context: { params: { id: str
   const id = Number(context.params.id);
   if (!Number.isFinite(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   await repo.delete({ where: { id } });

--- a/src/app/api/policies/route.ts
+++ b/src/app/api/policies/route.ts
@@ -2,6 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
+import { Prisma, PrismaClient } from "@prisma/client";
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 // getUserFromRequest imported from core auth
 
@@ -18,7 +21,7 @@ export async function GET(request: NextRequest) {
   const tenantId = searchParams.get("tenantId") || undefined;
 
   // optional repo access to compile even if model not generated yet
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ data: [], success: true, meta: { total: 0 } });
 
   const where: any = {};
@@ -49,7 +52,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "name, resource and effect are required" }, { status: 400 });
   }
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const created = await repo.create({

--- a/src/core/auth/casl.guard.ts
+++ b/src/core/auth/casl.guard.ts
@@ -4,6 +4,7 @@ import { AuthLogger } from "./auth.logger";
 import { subject as caslSubject } from "@casl/ability";
 import { PrismaQuery } from "@casl/prisma";
 import { prisma } from "../prisma";
+import { Prisma, PrismaClient } from "@prisma/client";
 
 export interface RequiredRule {
   action: string;
@@ -13,6 +14,8 @@ export interface RequiredRule {
 }
 
 type UserCtx = { sub: string; tenantId?: string; roles: string[] };
+
+type PrismaWithPolicy = PrismaClient & { resourcePolicy?: Prisma.ResourcePolicyDelegate };
 
 export function checkAbilities(
   rules: RequiredRule[],
@@ -117,7 +120,7 @@ export async function caslGuardWithPolicies(
 
     const subjects = Array.from(new Set(rules.map((r) => r.subject)));
     for (const subject of subjects) {
-      const repo = (prisma as unknown as { resourcePolicy?: { findMany: (args: unknown) => Promise<Array<{ effect: string; conditions: unknown }>> } }).resourcePolicy;
+      const repo = (prisma as PrismaWithPolicy).resourcePolicy;
       if (!repo) {
         // Client not generated for ResourcePolicy yet; skip ABAC and allow RBAC result
         break;


### PR DESCRIPTION
## Summary
- import Prisma and define PrismaWithPolicy type
- use PrismaWithPolicy to access optional resourcePolicy delegate

## Testing
- `npm test` *(fails: 8 failed, 5 passed)*
- `npm run lint` *(fails: require() style imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f14a8308329a6491aeaaabf19e9