### PR TITLE
chore: add types for user progress route

### DIFF
--- a/src/app/api/learning/progress/user/route.ts
+++ b/src/app/api/learning/progress/user/route.ts
@@ -4,8 +4,83 @@ import { prisma } from "@/core/prisma";
 import { getUserFromRequest } from "@/core/auth/getUser";
 import logger from "@/lib/logger";
 
+interface LessonProgressItem {
+  id: string;
+  lessonId: string;
+  lesson: {
+    id: string;
+    title: string;
+    difficulty: string;
+    estimatedMinutes: number | null;
+    course: {
+      id: string;
+      title: string;
+    };
+  };
+  status: "not_started" | "in_progress" | "completed" | "paused";
+  lastViewedAt: Date | null;
+  updatedAt: Date;
+}
+
+interface VocabularyProgressItem {
+  id: string;
+  vocabulary: {
+    id: string;
+    word: string;
+    meaning: string;
+    lesson: {
+      id: string;
+      title: string;
+    };
+  };
+  status: "new" | "reviewing" | "mastered";
+  lastReviewed: Date | null;
+}
+
+interface ProgressStats {
+  totalLessons: number;
+  completedLessons: number;
+  inProgressLessons: number;
+  totalVocabulary: number;
+  masteredVocabulary: number;
+  reviewingVocabulary: number;
+  newVocabulary: number;
+  totalTimeSpent: number;
+  totalInteractions: number;
+  learningStreak: number;
+  averageSessionTime: number;
+}
+
+interface Achievement {
+  type: string;
+  title: string;
+  description: string;
+  earnedAt: Date;
+}
+
+interface LevelProgression {
+  currentLevel: number;
+  totalPoints: number;
+  pointsToNextLevel: number;
+  completedLessons: number;
+  masteredVocabulary: number;
+}
+
+interface UserProgressResponse {
+  userId: string;
+  timeframe: string;
+  stats: ProgressStats;
+  levelProgression: LevelProgression;
+  recentAchievements: Achievement[];
+  lessonProgress?: LessonProgressItem[];
+  vocabularyProgress?: VocabularyProgressItem[];
+  recentSessions?: unknown[];
+}
+
 // GET /api/learning/progress/user - Get comprehensive user learning progress
-export async function GET(request: NextRequest) {
+export async function GET(
+  request: NextRequest
+): Promise<NextResponse<UserProgressResponse>> {
   try {
     // Get user from request
     const user = await getUserFromRequest(request);
@@ -35,7 +110,7 @@ export async function GET(request: NextRequest) {
     let dateFilter = {};
     if (timeframe !== "all") {
       const now = new Date();
-      let startDate = new Date();
+      const startDate = new Date();
 
       switch (timeframe) {
         case "week":
@@ -57,7 +132,8 @@ export async function GET(request: NextRequest) {
     }
 
     // Get lesson progress
-    const lessonProgress = await prisma.userProgress.findMany({
+    const lessonProgress: LessonProgressItem[] =
+      await prisma.userProgress.findMany({
       where: {
         userId: user.id,
         ...dateFilter,
@@ -84,7 +160,8 @@ export async function GET(request: NextRequest) {
     });
 
     // Get vocabulary progress
-    const vocabularyProgress = await prisma.userVocabularyProgress.findMany({
+    const vocabularyProgress: VocabularyProgressItem[] =
+      await prisma.userVocabularyProgress.findMany({
       where: {
         userId: user.id,
         ...(timeframe !== "all" && {
@@ -142,7 +219,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Calculate summary statistics
-    const stats = {
+    const stats: ProgressStats = {
       totalLessons: lessonProgress.length,
       completedLessons: lessonProgress.filter((p) => p.status === "completed")
         .length,
@@ -191,7 +268,7 @@ export async function GET(request: NextRequest) {
       stats
     );
 
-    const response = {
+    const response: UserProgressResponse = {
       userId: user.id,
       timeframe,
       stats,
@@ -216,7 +293,7 @@ export async function GET(request: NextRequest) {
       }),
     };
 
-    return NextResponse.json(response);
+    return NextResponse.json<UserProgressResponse>(response);
   } catch (error) {
     logger.error("Error fetching user progress", { userId: user?.id }, error);
     return NextResponse.json(
@@ -243,7 +320,7 @@ async function calculateLearningStreak(userId: string): Promise<number> {
   if (sessions.length === 0) return 0;
 
   let streak = 0;
-  let currentDate = new Date();
+  const currentDate = new Date();
   currentDate.setHours(0, 0, 0, 0);
 
   // Group sessions by date
@@ -266,9 +343,9 @@ async function calculateLearningStreak(userId: string): Promise<number> {
 
 // Calculate level progression based on completed lessons and vocabulary
 function calculateLevelProgression(
-  lessonProgress: any[],
-  vocabularyProgress: any[]
-) {
+  lessonProgress: LessonProgressItem[],
+  vocabularyProgress: VocabularyProgressItem[]
+): LevelProgression {
   const completedLessons = lessonProgress.filter(
     (p) => p.status === "completed"
   ).length;
@@ -292,11 +369,11 @@ function calculateLevelProgression(
 
 // Get recent achievements
 function getRecentAchievements(
-  lessonProgress: any[],
-  vocabularyProgress: any[],
-  stats: any
-) {
-  const achievements = [];
+  lessonProgress: LessonProgressItem[],
+  vocabularyProgress: VocabularyProgressItem[],
+  stats: ProgressStats
+): Achievement[] {
+  const achievements: Achievement[] = [];
 
   // Check for milestone achievements
   if (stats.completedLessons >= 10 && stats.completedLessons % 10 === 0) {


### PR DESCRIPTION
## Summary
- add interfaces for lesson/vocabulary progress, stats, and achievements
- use new types for prisma results and helper functions
- type GET handler response

## Testing
- `npm test` (fails: useAbility must be used within an AbilityProvider, ...)
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a01f1511d8832983787008c50419a4