### PR TITLE
refactor: tighten api typing

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -199,7 +199,7 @@ export interface FormField {
     minLength?: number;
     maxLength?: number;
     pattern?: RegExp;
-    custom?: (value: any) => boolean | string;
+    custom?: (value: unknown) => boolean | string;
   };
 }
 
@@ -209,11 +209,11 @@ export interface FormData {
 
 // State Management Types
 export interface StoreState {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export interface StoreActions {
-  [key: string]: (...args: any[]) => void;
+  [key: string]: (...args: unknown[]) => void;
 }
 
 export interface StoreSlice<T extends StoreState, A extends StoreActions> {


### PR DESCRIPTION
## Summary
- narrow FormField custom validation signature to unknown
- use unknown for store state and action args

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined (reading '1'))*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Argument of type 'unknown' is not assignable to parameter of type 'Error | undefined')*

------
https://chatgpt.com/codex/tasks/task_e_68a01f1a0db48329921bf467c5c85b92