### PR TITLE
refactor: type exercise results

### DIFF
--- a/src/app/learning/components/LearningApp.tsx
+++ b/src/app/learning/components/LearningApp.tsx
@@ -55,12 +55,13 @@ import type {
   LearningStory,
   Exercise,
   VocabularyData,
+  ExerciseResult,
 } from "../types/learning";
 
 interface LearningAppProps {
   story: LearningStory;
   onStoryComplete?: (storyId: string) => void;
-  onExerciseComplete?: (results: any[]) => void;
+  onExerciseComplete?: (results: ExerciseResult[]) => void;
   className?: string;
 }
 
@@ -167,7 +168,7 @@ export const LearningApp = React.memo(function LearningApp({
     onStoryComplete?.(story.id);
   };
 
-  const handleExerciseComplete = (results: unknown[]) => {
+  const handleExerciseComplete = (results: ExerciseResult[]) => {
     onExerciseComplete?.(results);
     setActivePanel("progress");
   };


### PR DESCRIPTION
## Summary
- import ExerciseResult for explicit exercise completion typing
- tighten LearningApp's exercise completion handlers to use ExerciseResult[]

## Testing
- `npm test` *(fails: Test Suites: 8 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f1d348c83299598dfbed4e3b3fb