### PR TITLE
feat(logging): send errors to LogRocket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Required: secret key for JWT signing
 JWT_SECRET=your-super-secret-jwt-key
+NEXT_PUBLIC_LOGROCKET_ID=your-logrocket-app-id

--- a/docs/LOGROCKET_MONITORING.md
+++ b/docs/LOGROCKET_MONITORING.md
@@ -1,0 +1,20 @@
+# LogRocket Monitoring
+
+This project uses [LogRocket](https://logrocket.com) to collect error logs in production. Any log with level `ERROR` or higher is sent to LogRocket when the application runs outside of development.
+
+## Setup
+
+1. Create a LogRocket project and copy its **App ID** (e.g. `your-org/your-app`).
+2. Add the App ID to your environment variables:
+
+```env
+NEXT_PUBLIC_LOGROCKET_ID=your-org/your-app
+```
+
+3. Build and run the application. LogRocket initializes automatically in non-development environments.
+
+## Viewing logs
+
+1. Sign in to the [LogRocket dashboard](https://logrocket.com).
+2. Select the project matching your App ID.
+3. Use the **Issues** or **Sessions** views to explore captured logs and playback sessions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "clsx": "^2.1.1",
         "framer-motion": "^11.11.17",
         "jsonwebtoken": "^9.0.2",
+        "logrocket": "^10.1.0",
         "lucide-react": "^0.460.0",
         "next": "15.3.5",
         "next-auth": "^4.24.10",
@@ -12903,6 +12904,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/logrocket": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/logrocket/-/logrocket-10.1.0.tgz",
+      "integrity": "sha512-wcVb+fkM7V6+nhUkhpTdnY/b31C5xy0hlEEs8UOMZiHFUrv0/2kIV+NjtmOlksniIQmUawC5ozw6ZID4qbJmUg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clsx": "^2.1.1",
     "framer-motion": "^11.11.17",
     "jsonwebtoken": "^9.0.2",
+    "logrocket": "^10.1.0",
     "lucide-react": "^0.460.0",
     "next": "15.3.5",
     "next-auth": "^4.24.10",

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,6 +3,8 @@
  * Replaces scattered console.log statements with structured logging
  */
 
+import LogRocket, { isLogRocketEnabled } from './logrocket';
+
 export enum LogLevel {
   DEBUG = 0,
   INFO = 1,
@@ -74,9 +76,12 @@ class Logger {
         break;
     }
 
-    // In production, you might want to send logs to external service
-    if (!this.isDevelopment && level >= LogLevel.ERROR) {
-      // TODO: Send to external logging service (e.g., Sentry, LogRocket)
+    if (!this.isDevelopment && level >= LogLevel.ERROR && isLogRocketEnabled) {
+      if (error) {
+        LogRocket.captureException(error, { extra: context });
+      } else {
+        LogRocket.captureMessage(formattedMessage, { extra: context });
+      }
     }
   }
 

--- a/src/lib/logrocket.ts
+++ b/src/lib/logrocket.ts
@@ -1,0 +1,11 @@
+import LogRocket from 'logrocket';
+
+const LOGROCKET_ID = process.env.NEXT_PUBLIC_LOGROCKET_ID;
+export const isLogRocketEnabled =
+  !!LOGROCKET_ID && typeof window !== 'undefined' && process.env.NODE_ENV !== 'development';
+
+if (isLogRocketEnabled) {
+  LogRocket.init(LOGROCKET_ID!);
+}
+
+export default LogRocket;


### PR DESCRIPTION
## Summary
- integrate LogRocket client to capture production errors
- forward error-level logs to LogRocket when not in development
- document LogRocket setup and monitoring

## Testing
- `npm test` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*
- `npm run lint` *(fails: Error: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f289a508329b91281dfdf488089