### PR TITLE
chore: type progress tests

### DIFF
--- a/src/__tests__/api/progress.test.ts
+++ b/src/__tests__/api/progress.test.ts
@@ -25,7 +25,7 @@ jest.mock("@/core/auth/casl.guard", () => ({
   caslGuardWithPolicies: jest.fn(),
 }));
 
-const mockPrisma = prisma as any;
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetUser = getUserFromRequest as jest.MockedFunction<
   typeof getUserFromRequest
 >;
@@ -41,13 +41,12 @@ describe("/api/progress/[id] DELETE", () => {
   it("deletes progress record", async () => {
     mockGetUser.mockResolvedValue({ sub: "u1", tenantId: "t1" });
     mockCasl.mockResolvedValue({ allowed: true, error: null });
-    mockPrisma.userProgress.findFirst.mockResolvedValue({ id: "p1" });
-    mockPrisma.userProgress.delete.mockResolvedValue({});
+    mockPrisma.userProgress.findFirst.mockResolvedValue({ id: "p1" } as any);
+    mockPrisma.userProgress.delete.mockResolvedValue({} as any);
 
-    const request = new NextRequest(
-      "http://localhost:3000/api/progress/p1",
-      { method: "DELETE" }
-    );
+    const request = new NextRequest("http://localhost:3000/api/progress/p1", {
+      method: "DELETE",
+    });
 
     const res = await DELETE(request, { params: { id: "p1" } });
 
@@ -62,14 +61,12 @@ describe("/api/progress/[id] DELETE", () => {
     mockCasl.mockResolvedValue({ allowed: true, error: null });
     mockPrisma.userProgress.findFirst.mockResolvedValue(null);
 
-    const request = new NextRequest(
-      "http://localhost:3000/api/progress/p1",
-      { method: "DELETE" }
-    );
+    const request = new NextRequest("http://localhost:3000/api/progress/p1", {
+      method: "DELETE",
+    });
 
     const res = await DELETE(request, { params: { id: "p1" } });
 
     expect(res.status).toBe(404);
   });
 });
-

--- a/src/__tests__/features/progress/hooks.test.tsx
+++ b/src/__tests__/features/progress/hooks.test.tsx
@@ -10,6 +10,7 @@ import {
   useUpsertProgress,
   useUpdateProgress,
   useDeleteProgress,
+  type UserProgress as Progress,
 } from "@/features/progress/hooks";
 import { api } from "@/core/api/api";
 
@@ -61,19 +62,19 @@ describe("Progress Hooks", () => {
 
     expect(mockApi).toHaveBeenCalledWith(
       "/api/progress?lessonId=l1",
-      expect.any(Object)
+      expect.any(Object),
     );
     expect(result.current.data).toEqual(mockProgress);
   });
 
   it("lists progress records", async () => {
-    const mockList = [] as any[];
+    const mockList: Progress[] = [];
     mockApi.mockResolvedValueOnce(mockList);
 
     const wrapper = createWrapper();
     const { result } = renderHook(
       () => useProgressList({ status: "completed" }),
-      { wrapper }
+      { wrapper },
     );
 
     await waitFor(() => {
@@ -82,7 +83,7 @@ describe("Progress Hooks", () => {
 
     expect(mockApi).toHaveBeenCalledWith(
       "/api/progress?status=completed",
-      expect.any(Object)
+      expect.any(Object),
     );
     expect(result.current.data).toEqual(mockList);
   });
@@ -159,7 +160,8 @@ describe("Progress Hooks", () => {
       expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(mockApi).toHaveBeenCalledWith("/api/progress/p1", { method: "DELETE" });
+    expect(mockApi).toHaveBeenCalledWith("/api/progress/p1", {
+      method: "DELETE",
+    });
   });
 });
-


### PR DESCRIPTION
## Summary
- refine progress hooks test typings using Progress interface
- cast prisma client mocks to jest.Mocked for api tests

## Testing
- `npm test src/__tests__/api/progress.test.ts src/__tests__/features/progress/hooks.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a01f2a84cc83299f733e494ffbd597