### PR TITLE
refactor: type resource policy prisma access

### DIFF
--- a/src/app/api/policies/[id]/route.ts
+++ b/src/app/api/policies/[id]/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { prisma } from "@/core/prisma";
 import { caslGuardWithPolicies } from "@/core/auth/casl.guard";
 import { getUserFromRequest } from "@/core/auth/getUser";
+
+type PrismaWithPolicy = PrismaClient & {
+  resourcePolicy?: Prisma.ResourcePolicyDelegate;
+};
 
 // getUserFromRequest imported from core auth
 
@@ -17,7 +22,7 @@ export async function PUT(_request: NextRequest, context: { params: { id: string
   if (!id) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
   const body = await _request.json();
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   const updated = await repo.update({
@@ -39,7 +44,7 @@ export async function DELETE(_request: NextRequest, context: { params: { id: str
   const id = Number(context.params.id);
   if (!Number.isFinite(id)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
-  const repo = (prisma as unknown as { resourcePolicy?: any }).resourcePolicy;
+  const repo = (prisma as PrismaWithPolicy).resourcePolicy;
   if (!repo) return NextResponse.json({ error: "Policy model not available" }, { status: 500 });
 
   await repo.delete({ where: { id } });


### PR DESCRIPTION
## Summary
- add PrismaWithPolicy type for optional resourcePolicy delegate
- replace any casts in policy routes

## Testing
- `npm run lint` *(fails: A `require()` style import is forbidden)*
- `npx eslint src/app/api/policies/route.ts src/app/api/policies/[id]/route.ts`
- `npm test` *(fails: 8 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f2facd48329b78bbdbf11b7c1c4