### PR TITLE
refactor: centralize auth token helpers

### DIFF
--- a/AUTHENTICATION_IMPROVEMENTS.md
+++ b/AUTHENTICATION_IMPROVEMENTS.md
@@ -132,7 +132,7 @@ const response = await api<User[]>('/api/users');
 
 ### 2. Manual Token Refresh
 ```typescript
-import { refreshToken } from '@/core/api/api';
+import { refreshToken } from '@/core/api/tokenManager';
 
 try {
   const newToken = await refreshToken();

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -8,7 +8,6 @@ import { Suspense, useEffect, useState } from "react";
 import AuthContextBridge from "@/core/auth/AuthContextBridge";
 import { TokenRefreshProvider } from "@/components/auth/TokenRefreshProvider";
 import { TokenDebugPanel } from "@/components/debug/TokenDebugPanel";
-import { tokenManager } from "@/core/api/api";
 
 function DevPanel() {
     if (process.env.NODE_ENV !== "development") return null;

--- a/src/components/debug/TokenDebugPanel.tsx
+++ b/src/components/debug/TokenDebugPanel.tsx
@@ -2,7 +2,7 @@
 import { logger } from '@/lib/logger';
 
 import { useState, useEffect } from 'react';
-import { getTokenStatus, refreshToken } from '@/core/api/api';
+import { getTokenStatus, refreshToken } from '@/core/api/tokenManager';
 import { useAuth } from '@/contexts/AuthContext';
 
 export function TokenDebugPanel() {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ import React, {
   useCallback,
 } from "react";
 import { useRouter } from "next/navigation";
-import { setAuthToken, getAuthToken, refreshToken } from "@/core/api/api";
+import { setAuthToken, getAuthToken, refreshToken } from "@/core/api/tokenManager";
 import { clearCSRFToken } from "@/core/api/csrf";
 import logger from "@/lib/logger";
 

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -1,190 +1,35 @@
 import { ApiError } from "./errorHandling";
 import logger from "@/lib/logger";
 import { getCSRFToken } from "./csrf";
+import {
+  tokenManager,
+  getAuthToken,
+  getRefreshToken,
+  refreshToken as refreshAuthToken,
+  clearAuthToken,
+} from "./tokenManager";
 
 /* ======================================
  * Types
  * ====================================== */
 // Enhanced request configuration interface
 export interface ApiRequestConfig extends RequestInit {
-    url: string;
-    timeout?: number;
-    retries?: number;
+  url: string;
+  timeout?: number;
+  retries?: number;
 }
 
 export type RequestInterceptor = (
-    config: ApiRequestConfig
+  config: ApiRequestConfig
 ) => ApiRequestConfig | Promise<ApiRequestConfig>;
 
 export type ResponseInterceptor = (response: Response) => Response | Promise<Response>;
 export type ErrorInterceptor = (error: Error) => Error | Promise<Error>;
 
-export interface TokenData {
-  accessToken: string;
-  refreshToken?: string;
-  expiresAt: number; // epoch ms
-  tokenType: "Bearer";
-}
-
 /* ======================================
  * Utils
  * ====================================== */
 const isClient = () => typeof window !== "undefined";
-const now = () => Date.now();
-
-/* ======================================
- * TokenStorage (localStorage only, SSR-safe)
- * ====================================== */
-const TOKEN_KEY = "auth_token_data";
-
-const TokenStorage = {
-  load(): TokenData | null {
-    if (!isClient()) return null;
-    const raw = localStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    try {
-      const json = typeof atob === "function" ? atob(raw) : raw;
-      return JSON.parse(json) as TokenData;
-    } catch {
-      return null;
-    }
-  },
-  save(data: TokenData | null) {
-    if (!isClient()) return;
-    if (!data) {
-      localStorage.removeItem(TOKEN_KEY);
-      return;
-    }
-    const json = JSON.stringify(data);
-    const encoded = typeof btoa === "function" ? btoa(json) : json;
-    localStorage.setItem(TOKEN_KEY, encoded);
-  },
-  clear() {
-    if (!isClient()) return;
-    localStorage.removeItem(TOKEN_KEY);
-  },
-};
-
-/* ======================================
- * TokenManager (singleton)
- * ====================================== */
-class TokenManager {
-  private static _instance: TokenManager | null = null;
-  static getInstance(): TokenManager {
-    if (!this._instance) this._instance = new TokenManager();
-    return this._instance;
-  }
-
-  private cached: TokenData | null = null;
-  private _initialized = false;
-
-  private refreshing = false;
-  private _refreshPromise: Promise<string | null> | null = null;
-  private readonly REFRESH_THRESHOLD = 5 * 60 * 1000; // 5 minutes
-
-  /** Expose refresh in-flight safely (read-only) */
-  getRefreshInFlight(): Promise<string | null> | null {
-    return this._refreshPromise;
-  }
-
-  /** Sync init to avoid race */
-  init(): void {
-    if (this._initialized) return;
-    if (isClient()) {
-      this.cached = TokenStorage.load();
-    }
-    this._initialized = true;
-  }
-
-  isInitialized(): boolean {
-    return this._initialized;
-  }
-
-  set(accessToken: string, expiresInSec = 3600, refreshToken?: string) {
-    this.init();
-    this.cached = {
-      accessToken,
-      refreshToken,
-      tokenType: "Bearer",
-      expiresAt: now() + expiresInSec * 1000,
-    };
-    TokenStorage.save(this.cached);
-  }
-
-  clear() {
-    this.cached = null;
-    TokenStorage.clear();
-  }
-
-  getAccessTokenSync(): string | null {
-    this.init();
-    if (!this.cached) return null;
-    if (now() >= this.cached.expiresAt) {
-      this.clear();
-      return null;
-    }
-    return this.cached.accessToken;
-  }
-
-  getRefreshTokenSync(): string | null {
-    this.init();
-    return this.cached?.refreshToken ?? null;
-  }
-
-  getExpiresAtSync(): number | null {
-    this.init();
-    return this.cached?.expiresAt ?? null;
-  }
-
-  isExpiringSoon(): boolean {
-    this.init();
-    if (!this.cached) return false;
-    return now() >= this.cached.expiresAt - this.REFRESH_THRESHOLD;
-  }
-
-  /** Single-flight refresh. Caller supplies actual refresh fetcher */
-  async refresh(
-      fetcher: (refreshToken: string) => Promise<{
-        accessToken: string;
-        expiresIn: number;
-        refreshToken?: string;
-      } | null>
-  ): Promise<string | null> {
-    if (this.refreshing && this._refreshPromise) return this._refreshPromise;
-
-    const rt = this.getRefreshTokenSync();
-    if (!rt) return null;
-
-    this.refreshing = true;
-    this._refreshPromise = (async () => {
-      try {
-        const result = await fetcher(rt);
-        if (!result) {
-          this.clear();
-          if (isClient()) {
-            window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-          }
-          return null;
-        }
-        this.set(result.accessToken, result.expiresIn, result.refreshToken);
-        return result.accessToken;
-      } catch {
-        this.clear();
-        if (isClient()) {
-          window.dispatchEvent(new CustomEvent("auth:token-refresh-failed"));
-        }
-        return null;
-      } finally {
-        this.refreshing = false;
-        this._refreshPromise = null;
-      }
-    })();
-
-    return this._refreshPromise;
-  }
-}
-
-export const tokenManager = TokenManager.getInstance();
 
 /* ======================================
  * ApiClient (fetch wrapper + interceptors)
@@ -261,61 +106,31 @@ export const apiClient = new ApiClient({
 });
 
 /* ======================================
- * Refresh fetcher (customize theo API của bạn)
- * ====================================== */
-const performRefresh = async (refreshToken: string) => {
-  const res = await fetch("/api/auth/refresh", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "same-origin",
-    body: JSON.stringify({ refreshToken }),
-  });
-  if (!res.ok) return null;
-  const data = (await res.json()) as {
-    accessToken: string;
-    expiresIn?: number;
-    refreshToken?: string;
-  };
-  return {
-    accessToken: data.accessToken,
-    expiresIn: data.expiresIn ?? 3600,
-    refreshToken: data.refreshToken,
-  };
-};
-
-/* ======================================
  * Default interceptors
  * ====================================== */
 apiClient.addRequestInterceptor(async (config) => {
-  // ensure token loaded (sync)
   tokenManager.init();
 
-  // wait in-flight refresh if any
   const inFlight = tokenManager.getRefreshInFlight();
   if (inFlight) await inFlight;
 
-  // proactive refresh if expiring soon and we have RT
-  if (tokenManager.isExpiringSoon() && tokenManager.getRefreshTokenSync()) {
-    await tokenManager.refresh(performRefresh);
+  if (tokenManager.isExpiringSoon() && getRefreshToken()) {
+    await refreshAuthToken();
   }
 
   const headers = new Headers(config.headers as HeadersInit);
 
-  // attach access token
-  const access = tokenManager.getAccessTokenSync();
+  const access = getAuthToken();
   if (access) headers.set("Authorization", `Bearer ${access}`);
 
-  // attach CSRF for non-GET
   const method = (config.method || "GET").toUpperCase();
   if (!["GET", "HEAD", "OPTIONS"].includes(method)) {
     const csrf = await getCSRFToken();
     if (csrf) headers.set("X-CSRF-Token", csrf);
   }
 
-  // tracing & security
   headers.set("X-Requested-With", "XMLHttpRequest");
   if (isClient() && "randomUUID" in crypto) {
-    // TS types available if lib "DOM" is enabled
     headers.set("X-Request-ID", (crypto as Crypto).randomUUID());
   }
 
@@ -332,16 +147,16 @@ apiClient.addErrorInterceptor(async (error) => {
   if (!(error instanceof ApiError)) return error;
 
   if (error.status === 401) {
-    const hasRT = !!tokenManager.getRefreshTokenSync();
+    const hasRT = !!getRefreshToken();
     if (!hasRT) {
-      tokenManager.clear();
+      clearAuthToken();
       if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
       return error;
     }
 
-    const newToken = await tokenManager.refresh(performRefresh);
+    const newToken = await refreshAuthToken();
     if (!newToken) {
-      tokenManager.clear();
+      clearAuthToken();
       if (isClient()) window.dispatchEvent(new CustomEvent("auth:unauthorized"));
     }
   }
@@ -353,40 +168,21 @@ apiClient.addErrorInterceptor(async (error) => {
  * Public API (giữ tên export để không vỡ import cũ)
  * ====================================== */
 // Note: Use <T,> to avoid JSX parsing issues in environments that parse TS as TSX
-export const api = <T = unknown,>(input: RequestInfo, init?: RequestInit): Promise<T> =>
-    apiClient.request<T>(input, init);
-
-export const setAuthToken = (
-    token: string | null,
-    expiresIn?: number,
-    refreshToken?: string
-): void => {
-  if (token) tokenManager.set(token, expiresIn, refreshToken);
-  else tokenManager.clear();
-};
-
-export const getAuthToken = (): string | null => tokenManager.getAccessTokenSync();
-export const getRefreshToken = (): string | null => tokenManager.getRefreshTokenSync();
-export const isTokenExpiringSoon = (): boolean => tokenManager.isExpiringSoon();
-
-export const refreshToken = (): Promise<string | null> => tokenManager.refresh(performRefresh);
-
-export const getTokenStatus = (): {
-  hasToken: boolean;
-  isExpiringSoon: boolean;
-  expiresAt: number | null;
-  refreshInFlight: boolean;
-} => {
-  const access = tokenManager.getAccessTokenSync();
-  const refresh = tokenManager.getRefreshTokenSync();
-  const expiring = tokenManager.isExpiringSoon();
-  return {
-    hasToken: !!access || !!refresh,
-    isExpiringSoon: expiring,
-    expiresAt: tokenManager.getExpiresAtSync(),
-    refreshInFlight: tokenManager.getRefreshInFlight() !== null,
-  };
-};
+export const api = <T = unknown,>(
+  input: RequestInfo,
+  init?: RequestInit
+): Promise<T> => apiClient.request<T>(input, init);
 
 // Named exports for advanced usage
 export { ApiError } from "./errorHandling";
+export {
+  tokenManager,
+  setAuthToken,
+  getAuthToken,
+  getRefreshToken,
+  isTokenExpiringSoon,
+  refreshToken,
+  getTokenStatus,
+  clearAuthToken,
+} from "./tokenManager";
+

--- a/src/core/api/tokenManager.ts
+++ b/src/core/api/tokenManager.ts
@@ -1,4 +1,4 @@
-import type { TokenData, RefreshTokenResponse } from "./types";
+import type { TokenData, RefreshTokenResponse, TokenStatus } from "./types";
 
 /* ======================================
  * Utils
@@ -182,6 +182,18 @@ export const getRefreshToken = (): string | null =>
 export const isTokenExpiringSoon = (): boolean => tokenManager.isExpiringSoon();
 
 export const getExpiresAt = (): number | null => tokenManager.getExpiresAtSync();
+
+export const getTokenStatus = (): TokenStatus => {
+  const access = tokenManager.getAccessTokenSync();
+  const refresh = tokenManager.getRefreshTokenSync();
+  return {
+    hasAccessToken: !!access,
+    hasRefreshToken: !!refresh,
+    isExpiringSoon: tokenManager.isExpiringSoon(),
+    accessTokenLength: access?.length ?? 0,
+    refreshTokenLength: refresh?.length ?? 0,
+  };
+};
 
 const performRefresh = async (
   refreshToken: string

--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -1,7 +1,7 @@
 import { logger } from '@/lib/logger';
 import { useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
-import { isTokenExpiringSoon, refreshToken } from '@/core/api/api';
+import { isTokenExpiringSoon, refreshToken } from '@/core/api/tokenManager';
 
 interface UseTokenRefreshOptions {
   /**


### PR DESCRIPTION
## Summary
- refactor API client to use unified token manager
- expose token status and helper exports from tokenManager
- update imports to shared token module and docs

## Testing
- `npm test` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f4ac98c8329a03f5dec36d9af5c