### PR TITLE
feat(api): set default content-type header

### DIFF
--- a/src/__tests__/core/api/formData.test.ts
+++ b/src/__tests__/core/api/formData.test.ts
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment node
+ */
+
+import { apiClient } from "@/core/api/api";
+
+describe("apiClient FormData submission", () => {
+  it("submits FormData without setting Content-Type", async () => {
+    const fd = new FormData();
+    fd.append("field", "value");
+
+    const fetchMock = jest.fn().mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      )
+    );
+
+    const originalFetch = global.fetch;
+    // @ts-ignore override for test
+    global.fetch = fetchMock;
+
+    const result = await apiClient.request("/test", { method: "POST", body: fd });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, options] = fetchMock.mock.calls[1];
+    const headers = options?.headers as Headers;
+    expect(headers.get("Content-Type")).toBeNull();
+
+    // restore original fetch
+    global.fetch = originalFetch;
+  });
+});

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -215,13 +215,15 @@ class ApiClient {
 
   async request<T = unknown>(input: RequestInfo, init?: RequestInit): Promise<T> {
     try {
+      const headers = new Headers(init?.headers);
+      if (!headers.has("Content-Type") && !(init?.body instanceof FormData)) {
+        headers.set("Content-Type", "application/json");
+      }
+
       let config: RequestInit & { url: string } = {
         ...init,
         url: this.resolveURL(input),
-        headers: {
-          "Content-Type": "application/json",
-          ...(init?.headers || {}),
-        },
+        headers,
         signal: init?.signal,
       };
 


### PR DESCRIPTION
## Summary
- default to JSON content-type unless headers already specify or body is FormData
- add test verifying FormData submission doesn't override content type

## Testing
- `npm test`
- `npm test src/__tests__/core/api/formData.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a01f4d1e2c83298606d4e512c904d3