### PR TITLE
feat(api): add timeout and retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,6 +861,18 @@ This project is **proprietary software** designed for educational purposes.
 - Contributions welcome under CLA
 - Open source components remain under their respective licenses
 
+## API Client Usage
+
+The API helper now supports request timeouts and automatic retries for transient errors:
+
+```ts
+import { api } from "@/core/api/api";
+
+await api("/endpoint", { timeout: 5000, retries: 3 });
+```
+
+`timeout` is in milliseconds and aborts the request when exceeded. `retries` specifies how many times to retry on network errors or 5xx responses.
+
 ---
 
 ## 🌟 Acknowledgments

--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -8,7 +8,9 @@ import { getCSRFToken } from "./csrf";
 // Enhanced request configuration interface
 export interface ApiRequestConfig extends RequestInit {
     url: string;
+    /** Aborts the request after the specified milliseconds */
     timeout?: number;
+    /** Number of retry attempts for transient failures */
     retries?: number;
 }
 
@@ -213,9 +215,9 @@ class ApiClient {
     return url; // prefer relative path on client
   }
 
-  async request<T = unknown>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  async request<T = unknown>(input: RequestInfo, init?: ApiRequestConfig): Promise<T> {
     try {
-      let config: RequestInit & { url: string } = {
+      let config: ApiRequestConfig & { url: string } = {
         ...init,
         url: this.resolveURL(input),
         headers: {
@@ -223,29 +225,67 @@ class ApiClient {
           ...(init?.headers || {}),
         },
         signal: init?.signal,
+        timeout: init?.timeout,
+        retries: init?.retries,
       };
 
       for (const i of this.requestInterceptors) {
         config = await i(config);
       }
 
-      let response = await fetch(config.url, config);
+      const retries = config.retries ?? 0;
+      let attempt = 0;
+      const { url, timeout, signal, retries: _r, ...rest } = config;
 
-      for (const i of this.responseInterceptors) {
-        response = await i(response);
+      while (true) {
+        const controller = new AbortController();
+        if (signal) {
+          const s = signal as AbortSignal;
+          if (s.aborted) controller.abort();
+          else s.addEventListener("abort", () => controller.abort(), { once: true });
+        }
+        const timeoutId =
+          typeof timeout === "number"
+            ? setTimeout(() => controller.abort(), timeout)
+            : undefined;
+
+        try {
+          let response = await fetch(url, { ...rest, signal: controller.signal });
+
+          if (timeoutId) clearTimeout(timeoutId);
+
+          for (const i of this.responseInterceptors) {
+            response = await i(response);
+          }
+
+          const isJson = response.headers.get("content-type")?.includes("application/json");
+          const body: unknown = isJson ? await response.json().catch(() => undefined) : undefined;
+
+          if (!response.ok) {
+            const shouldRetry =
+              attempt < retries && response.status >= 500 && response.status < 600;
+            if (shouldRetry) {
+              attempt++;
+              continue;
+            }
+            type ErrorBody = { message?: string; error?: string; [k: string]: unknown };
+            const obj = (typeof body === "object" && body !== null) ? (body as ErrorBody) : undefined;
+            const message = obj?.message || obj?.error || `HTTP ${response.status}`;
+            throw new ApiError(message, response.status, body, `HTTP_${response.status}`);
+          }
+
+          return (body as T) ?? (await response.text() as unknown as T);
+        } catch (err) {
+          if (timeoutId) clearTimeout(timeoutId);
+          const e = err as Error;
+          const isTransient = e.name === "AbortError" || e instanceof TypeError;
+          if (attempt < retries && isTransient) {
+            attempt++;
+            continue;
+          }
+          throw e;
+        }
       }
-
-      const isJson = response.headers.get("content-type")?.includes("application/json");
-      const body: unknown = isJson ? await response.json().catch(() => undefined) : undefined;
-
-      if (!response.ok) {
-        type ErrorBody = { message?: string; error?: string; [k: string]: unknown };
-        const obj = (typeof body === "object" && body !== null) ? (body as ErrorBody) : undefined;
-        const message = obj?.message || obj?.error || `HTTP ${response.status}`;
-        throw new ApiError(message, response.status, body, `HTTP_${response.status}`);
-      }
-
-      return (body as T) ?? (await response.text() as unknown as T);
     } catch (err) {
       let e = err as Error;
       for (const i of this.errorInterceptors) {


### PR DESCRIPTION
## Summary
- add `timeout` and `retries` handling to ApiClient
- document API client timeout/retry options

## Testing
- `npm test` *(fails: useAbility must be used within an AbilityProvider)*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f4d8d188329bd7e766224f48779