### PR TITLE
Validate accessibility settings with Zod

### DIFF
--- a/src/app/learning/contexts/AccessibilityContext.tsx
+++ b/src/app/learning/contexts/AccessibilityContext.tsx
@@ -9,14 +9,17 @@ import React, {
   ReactNode,
 } from "react";
 import { HighContrastManager, AriaLiveAnnouncer } from "../utils/accessibility";
+import { z } from "zod";
 
-interface AccessibilitySettings {
-  highContrast: boolean;
-  reducedMotion: boolean;
-  fontSize: "small" | "medium" | "large" | "extra-large";
-  keyboardNavigation: boolean;
-  screenReaderOptimized: boolean;
-}
+const accessibilitySettingsSchema = z.object({
+  highContrast: z.boolean(),
+  reducedMotion: z.boolean(),
+  fontSize: z.enum(["small", "medium", "large", "extra-large"]),
+  keyboardNavigation: z.boolean(),
+  screenReaderOptimized: z.boolean(),
+});
+
+type AccessibilitySettings = z.infer<typeof accessibilitySettingsSchema>;
 
 interface AccessibilityContextType {
   settings: AccessibilitySettings;
@@ -78,9 +81,27 @@ export function AccessibilityProvider({
     if (savedSettings) {
       try {
         const parsed = JSON.parse(savedSettings);
-        setSettings((prev) => ({ ...prev, ...parsed }));
+        const result = accessibilitySettingsSchema.safeParse(parsed);
+        if (result.success) {
+          setSettings((prev) => ({ ...prev, ...result.data }));
+        } else {
+          logger.warn(
+            "Invalid saved accessibility settings:",
+            result.error
+          );
+          setSettings((prev) => ({
+            ...defaultSettings,
+            highContrast: prev.highContrast,
+            reducedMotion: prev.reducedMotion,
+          }));
+        }
       } catch (error) {
         logger.warn("Failed to parse saved accessibility settings:", error);
+        setSettings((prev) => ({
+          ...defaultSettings,
+          highContrast: prev.highContrast,
+          reducedMotion: prev.reducedMotion,
+        }));
       }
     }
 


### PR DESCRIPTION
## Summary
- add Zod schema for AccessibilitySettings
- validate saved accessibility settings before applying
- warn and revert to defaults on invalid data

## Testing
- `npm test --silent` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f50510c8329acd9915d12356062