### PR TITLE
refactor: use slice for offline session IDs

### DIFF
--- a/src/app/learning/hooks/useOfflineProgress.ts
+++ b/src/app/learning/hooks/useOfflineProgress.ts
@@ -127,7 +127,7 @@ export function useOfflineProgress(userId: string) {
   // Start a new learning session
   const startLearningSession = useCallback((storyId: string) => {
     const session: LearningSession = {
-      id: `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+      id: `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`,
       storyId,
       startTime: new Date(),
       timeSpent: 0,


### PR DESCRIPTION
## Summary
- replace deprecated `substr` with `slice` for offline learning session IDs

## Testing
- `node -e "for (let i=0;i<5;i++){const id=Math.random().toString(36).slice(2,11); console.log(id, id.length);}"`
- `npm test` *(fails: Test Suites: 8 failed, 5 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f5392b48329905fdcae570c0161