### PR TITLE
refactor: remove redundant login input check

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -45,14 +45,6 @@ export async function POST(request: NextRequest) {
       }
       const { email, password } = parsed.data;
 
-    // Validate input
-    if (!email || !password) {
-      return NextResponse.json(
-        { message: "Dữ liệu không hợp lệ", errors: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
-
     // Find user by email
     const user = await prisma.user.findUnique({
       where: { email },


### PR DESCRIPTION
## Summary
- drop redundant email/password check in login route
- rely on zod validation so parsed.error is only used on failure

## Testing
- `npx tsx -e "import { NextRequest } from 'next/server'; import { POST } from './src/app/api/auth/login/route'; const req = new NextRequest('http://localhost:3000/api/auth/login',{method:'POST',body: JSON.stringify({ email: 'test@example.com' }), headers:{'content-type':'application/json'}}); POST(req).then(async res=>{console.log('status', res.status); console.log('body', await res.json());});"`
- `npm test` *(fails: useAbility must be used within an AbilityProvider, etc.)*
- `npm run lint` *(no output, process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f56b1bc8329b30aec398fe50850