### PR TITLE
refactor: use verifyJwt in getUser

### DIFF
--- a/src/core/auth/getUser.ts
+++ b/src/core/auth/getUser.ts
@@ -37,18 +37,7 @@ export async function getUserFromRequest(
     }
     if (!token) return null;
 
-    const secret = process.env.JWT_SECRET;
-    if (!secret) {
-      if (process.env.NODE_ENV !== "production") {
-        logger.warn("getUserFromRequest: JWT_SECRET is not set; failing closed.");
-      }
-      return null;
-    }
-
-    const decoded = jwt.verify(token, secret, {
-      algorithms: ["HS256"],
-      ignoreExpiration: false,
-    }) as JWTPayload;
+    const decoded = verifyJwt<JWTPayload>(token);
 
     return {
       sub: decoded.userId,
@@ -57,7 +46,7 @@ export async function getUserFromRequest(
     };
   } catch (err) {
     if (process.env.NODE_ENV !== "production") {
-      logger.warn("getUserFromRequest: token verification failed:", err);
+      logger.warn("getUserFromRequest: token verification failed:", { err });
     }
     return null;
   }


### PR DESCRIPTION
## Summary
- use centralized `verifyJwt` helper in getUser
- fix logger invocation for token verification errors

## Testing
- `npx tsc -p tsconfig.json --noEmit 2>&1 | rg "src/core/auth/getUser.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68a01f58609883299e9a31da7d2b4b20