### PR TITLE
feat(api): honor headers instance and FormData

### DIFF
--- a/src/core/api/api.ts
+++ b/src/core/api/api.ts
@@ -217,13 +217,15 @@ class ApiClient {
   async request<T>(input: RequestInfo, init?: RequestInit): Promise<T>;
   async request<T>(input: RequestInfo, init?: RequestInit): Promise<T | string> {
     try {
+      const headers = new Headers(init?.headers);
+      if (!headers.has("Content-Type") && !(init?.body instanceof FormData)) {
+        headers.set("Content-Type", "application/json");
+      }
+
       let config: RequestInit & { url: string } = {
         ...init,
         url: this.resolveURL(input),
-        headers: {
-          "Content-Type": "application/json",
-          ...(init?.headers || {}),
-        },
+        headers,
         signal: init?.signal,
       };
 


### PR DESCRIPTION
## Summary
- construct headers via `Headers` and default JSON content-type only when appropriate
- test FormData requests to ensure `Content-Type` isn't overwritten

## Testing
- `npm test src/__tests__/core/api/api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a06f60e08c832991783e59af13f16c