### PR TITLE
refactor: type service worker responses

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -236,32 +236,32 @@ self.addEventListener("message", (event) => {
     case "CACHE_STORY":
       cacheStory(data)
         .then(() => {
-          event.ports[0].postMessage({ success: true });
+          event.ports[0].postMessage({ data: { success: true } });
         })
         .catch((error) => {
-          event.ports[0].postMessage({ success: false, error: error.message });
+          event.ports[0].postMessage({ error: error.message });
         });
       break;
 
     case "CACHE_AUDIO":
       cacheAudio(data)
         .then(() => {
-          event.ports[0].postMessage({ success: true });
+          event.ports[0].postMessage({ data: { success: true } });
         })
         .catch((error) => {
-          event.ports[0].postMessage({ success: false, error: error.message });
+          event.ports[0].postMessage({ error: error.message });
         });
       break;
 
     case "GET_CACHE_STATUS":
       getCacheStatus().then((status) => {
-        event.ports[0].postMessage(status);
+        event.ports[0].postMessage({ data: status });
       });
       break;
 
     case "CLEAR_CACHE":
       clearCache(data.cacheType).then(() => {
-        event.ports[0].postMessage({ success: true });
+        event.ports[0].postMessage({ data: { success: true } });
       });
       break;
   }


### PR DESCRIPTION
## Summary
- add `ServiceWorkerResponse` interface and type-safe message handling in offline manager
- wrap service worker messages with `{data, error}` envelope
- specify concrete response types when sending messages to the service worker

## Testing
- `npm test` *(fails: Test Suites: 9 failed, 10 passed)*
- `npm run lint` *(fails: ESLint rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af621bc08329952fe4a8205b64a9