### PR TITLE
test: use jest mocked prisma in story audio test

### DIFF
--- a/src/__tests__/api/storyAudio.test.ts
+++ b/src/__tests__/api/storyAudio.test.ts
@@ -28,7 +28,7 @@ jest.mock("@/lib/storage", () => ({
   getAudioSignedUrl: jest.fn(),
 }));
 
-const mockPrisma = prisma as any;
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
 const mockGetUser = getUserFromRequest as jest.MockedFunction<typeof getUserFromRequest>;
 const mockCasl = caslGuardWithPolicies as jest.MockedFunction<typeof caslGuardWithPolicies>;
 const mockGetSignedUrl = getAudioSignedUrl as jest.MockedFunction<typeof getAudioSignedUrl>;


### PR DESCRIPTION
## Summary
- type `mockPrisma` using `jest.Mocked<typeof prisma>` in story audio test

## Testing
- `AWS_S3_BUCKET=test AWS_REGION=us-east-1 AUDIO_STREAM=false npm test src/__tests__/api/storyAudio.test.ts` *(fails: CredentialsProviderError)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af68716083299aacc080081d9661