### PR TITLE
feat: use logger in vocabulary review hook

### DIFF
--- a/src/app/learning/hooks/useVocabularyReview.ts
+++ b/src/app/learning/hooks/useVocabularyReview.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import logger from "@/lib/logger";
 import type {
   UserLearningPreferences,
   VocabularyProgress,
@@ -332,7 +333,7 @@ export function useVocabularyReview(
         generateReviewSchedule(updatedProgress);
         setError(null);
       } catch (err) {
-        console.error("Error updating vocabulary progress:", err);
+        logger.error("Error updating vocabulary progress", { err });
         setError("Không thể cập nhật tiến độ từ vựng");
       }
     },


### PR DESCRIPTION
## Summary
- replace console error with shared logger in vocabulary review hook
- import logger utility

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0af62fbdc83299dc4f7b8bfa136d3