### PR TITLE
Remove duplicate logger import in TokenDebugPanel

### DIFF
--- a/src/components/debug/TokenDebugPanel.tsx
+++ b/src/components/debug/TokenDebugPanel.tsx
@@ -4,7 +4,6 @@ import { logger } from '@/lib/logger';
 import { useState, useEffect } from 'react';
 import { getTokenStatus, refreshToken, TokenStatus } from '@/core/api/api';
 import { useAuth } from '@/contexts/AuthContext';
-import { logger } from '@/lib/logger';
 
 export function TokenDebugPanel() {
   const [tokenStatus, setTokenStatus] = useState<TokenStatus | null>(null);


### PR DESCRIPTION
## Summary
- remove duplicated logger import from TokenDebugPanel

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a129e1e414832997bd07531ed94c9b