### PR TITLE
refactor: update default theme typing

### DIFF
--- a/src/app/learning/hooks/useUserPreferences.ts
+++ b/src/app/learning/hooks/useUserPreferences.ts
@@ -2,17 +2,14 @@
 import { logger } from '@/lib/logger';
 
 import { useState, useEffect, useCallback } from "react";
-import type {
-  UserLearningPreferences,
-  ThemePreference,
-} from "../types/learning";
+import type { UserLearningPreferences } from "../types/learning";
 import { DifficultyLevel, StoryType } from "@prisma/client";
 
 // Default preferences
-const DEFAULT_PREFERENCES: UserLearningPreferences = {
+const DEFAULT_PREFERENCES = {
   embeddingRatio: 20,
   difficultyLevel: "beginner",
-  theme: "light" as ThemePreference,
+  theme: "light",
   topicPreferences: ["original", "chemdanhtu"],
   audioEnabled: true,
   autoPlayAudio: false,
@@ -20,7 +17,7 @@ const DEFAULT_PREFERENCES: UserLearningPreferences = {
   vocabularyReviewFrequency: "daily",
   dailyGoal: 20,
   notificationsEnabled: true,
-};
+} satisfies UserLearningPreferences;
 
 const STORAGE_KEY = "learning-preferences";
 


### PR DESCRIPTION
## Summary
- remove ThemePreference cast from default preferences
- ensure default preferences satisfy UserLearningPreferences for literal typing

## Testing
- `npm test` *(fails: 12 failed, 7 passed)*
- `npm run lint` *(fails: A require() style import is forbidden, Use "@ts-expect-error" instead of "@ts-ignore", etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a17c6783ac8329be1d2687f2bcd6da